### PR TITLE
$this cannot be used in static methods

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -212,7 +212,7 @@ class WP_Piwik {
 		self::$logger->log ( 'Running WP-Piwik uninstallation' );
 		if (! defined ( 'WP_UNINSTALL_PLUGIN' ))
 			exit ();
-		$this->deleteWordPressOption ( 'wp-piwik-notices' );
+		self::deleteWordPressOption ( 'wp-piwik-notices' );
 		self::$settings->resetSettings ( true );
 	}
 


### PR DESCRIPTION
Got an warning in VS Code, seems there is a forgotten `$this`.