### PR TITLE
fix external Matomo request that was being sent on every WP frontend page view

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,10 @@
 .gitattributes   export-ignore
-/.github          export-ignore
-/tests            export-ignore
+/.github         export-ignore
+/tests           export-ignore
 .phpcs.xml.dist  export-ignore
 .wp-env.json     export-ignore
 phpstan.neon     export-ignore
 phpunit.xml.dist export-ignore
+.editorconfig    export-ignore
+/scripts         export-ignore
+

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -1447,6 +1447,7 @@ class WP_Piwik {
 			self::$settings->set_option( 'tracking_code', $result ['script'], $blog_id );
 			self::$settings->set_option( 'noscript_code', $result ['noscript'], $blog_id );
 			self::$settings->set_global_option( 'proxy_url', $result ['proxy'] );
+			self::$settings->save();
 			return $result['script'];
 		}
 		return false;

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,7 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 * Update tracker proxy to latest version.
 * New: added a "Cookie allow list" tracking option that restricts which cookies the tracking proxy forwards to Matomo (comma-separated list of cookie names, trailing * matches by prefix). Disabled by default.
 * Security: the tracking proxy now always removes known WordPress cookies (login/session, settings, comment author, etc.) and the PHP session cookie before forwarding a request to Matomo. Authentication cookies renamed through the wp-config.php cookie constants are recognised as well. Matomo opt out cookies are always forwarded.
+* Bug fix: fix external Matomo request that occurred on every frontend page view.
 
 = 1.1.9 =
 * Bug fix: correctly check clear parameter value.

--- a/tests/phpunit/RestIntegrationTest.php
+++ b/tests/phpunit/RestIntegrationTest.php
@@ -7,10 +7,7 @@ use WP_Piwik\Request\Rest;
 
 class RestIntegrationTest extends WP_Piwik_TestCase {
 
-	/**
-	 * @var string
-	 */
-	private $runtime;
+	use Mock_Matomo_Endpoint;
 
 	public function set_up() {
 		parent::set_up();
@@ -19,57 +16,8 @@ class RestIntegrationTest extends WP_Piwik_TestCase {
 			self::markTestSkipped( 'Not in wp-env environment, cannot run this test' );
 		}
 
-		$this->runtime = __DIR__ . '/rest/mock/runtime';
-		if ( ! is_dir( $this->runtime ) ) {
-			mkdir( $this->runtime, 0777, true );
-		}
-
-		// the mock runs as the web server user, the tests as the cli user
-		chmod( $this->runtime, 0777 );
-		$this->write_runtime_file( 'requests.jsonl', '' );
+		$this->set_up_mock_endpoint();
 		$this->set_mock_response( [ 'echo_bulk' => true ] );
-	}
-
-	private static function is_in_wp_env_environment() {
-		return defined( 'IN_WP_ENV' ) && IN_WP_ENV;
-	}
-
-	private function write_runtime_file( $name, $contents ) {
-		file_put_contents( $this->runtime . '/' . $name, $contents );
-		chmod( $this->runtime . '/' . $name, 0666 );
-	}
-
-	private function set_mock_response( array $response ) {
-		$this->write_runtime_file( 'response.json', wp_json_encode( $response ) );
-	}
-
-	private function get_captured_requests() {
-		$raw = file_get_contents( $this->runtime . '/requests.jsonl' );
-		if ( '' === trim( (string) $raw ) ) {
-			return [];
-		}
-		$requests = [];
-		foreach ( explode( "\n", trim( $raw ) ) as $line ) {
-			if ( '' !== $line ) {
-				$requests[] = json_decode( $line, true );
-			}
-		}
-		return $requests;
-	}
-
-	/**
-	 * @param bool $trailing_slash true to add a trailing slash, false if otherwise.
-	 *
-	 *                             A URL without the trailing slash makes the web
-	 *                             server answer with a 301 to URL with a slash.
-	 */
-	private function mock_url( $trailing_slash = true ) {
-		$host         = getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) ? getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) : 'tests-wordpress';
-		$plugins_path = wp_parse_url( plugins_url(), PHP_URL_PATH );
-		$plugin_dir   = basename( dirname( __DIR__, 2 ) );
-
-		return 'http://' . $host . rtrim( $plugins_path, '/' ) . '/' . $plugin_dir
-			. '/tests/phpunit/rest/mock' . ( $trailing_slash ? '/' : '' );
 	}
 
 	private function perform_bulk_request( $url, $connection, $method ) {

--- a/tests/phpunit/WpPiwikTest.php
+++ b/tests/phpunit/WpPiwikTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request\Rest;
+
+class WpPiwikTest extends WP_Piwik_TestCase {
+
+	use Mock_Matomo_Endpoint;
+
+	/**
+	 * Higher than WP_Piwik's own revision id, so the constructor treats the site as up to date
+	 * and skips the install and upgrade routines.
+	 */
+	const INSTALLED_REVISION = 99999999999;
+
+	/**
+	 * @var \WP_Piwik
+	 */
+	private $wp_piwik;
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! self::is_in_wp_env_environment() ) {
+			self::markTestSkipped( 'Not in wp-env environment, cannot run this test' );
+		}
+
+		$this->set_up_mock_endpoint();
+		$this->answer_with_tracking_code( $this->get_matomo_tracking_code() );
+		$this->configure_plugin();
+	}
+
+	public function test_update_tracking_code_returns_the_tracking_code_matomo_sent() {
+		$script = $this->wp_piwik->update_tracking_code( 1 );
+
+		$this->assertStringContainsString( "_paq.push(['trackPageView']);", $script );
+		$this->assertStringNotContainsString( '<noscript>', $script );
+	}
+
+	public function test_update_tracking_code_stores_the_tracking_code_for_the_next_request() {
+		$this->wp_piwik->update_tracking_code( 1 );
+
+		$this->assertStringContainsString(
+			"_paq.push(['trackPageView']);",
+			get_option( 'wp-piwik-tracking_code' )
+		);
+		$this->assertStringContainsString( '<noscript>', get_option( 'wp-piwik-noscript_code' ) );
+		$this->assertNotEmpty( get_option( 'wp-piwik-last_tracking_code_update' ) );
+	}
+
+	public function test_update_tracking_code_stores_the_proxy_url_for_the_next_request() {
+		$this->wp_piwik->update_tracking_code( 1 );
+
+		$this->assertSame( '//stats.example.org/', get_option( 'wp-piwik_global-proxy_url' ) );
+	}
+
+	public function test_update_tracking_code_asks_matomo_for_the_javascript_tag_of_the_configured_site() {
+		$this->wp_piwik->update_tracking_code( 1 );
+
+		$urls = $this->get_requested_api_urls();
+
+		$this->assertNotEmpty( $urls );
+		$this->assertStringContainsString( 'method=SitesManager.getJavascriptTag', $urls[0] );
+		$this->assertStringContainsString( 'idSite=1', $urls[0] );
+	}
+
+	public function test_update_tracking_code_passes_the_configured_tracking_options_to_matomo() {
+		$this->configure_plugin(
+			[
+				'track_across'              => true,
+				'track_across_alias'        => true,
+				'disable_cookies'           => true,
+				'track_crossdomain_linking' => true,
+			]
+		);
+
+		$this->wp_piwik->update_tracking_code( 1 );
+
+		$urls = $this->get_requested_api_urls();
+
+		$this->assertNotEmpty( $urls );
+		$this->assertStringContainsString( 'mergeSubdomains=1', $urls[0] );
+		$this->assertStringContainsString( 'mergeAliasUrls=1', $urls[0] );
+		$this->assertStringContainsString( 'disableCookies=1', $urls[0] );
+		$this->assertStringContainsString( 'crossDomain=1', $urls[0] );
+	}
+
+	public function test_update_tracking_code_uses_the_site_id_of_the_blog_when_none_is_given() {
+		$this->configure_plugin( [], [ 'site_id' => 4 ] );
+
+		$this->wp_piwik->update_tracking_code();
+
+		$urls = $this->get_requested_api_urls();
+
+		$this->assertNotEmpty( $urls );
+		$this->assertStringContainsString( 'idSite=4', $urls[0] );
+	}
+
+	/**
+	 * @dataProvider get_track_modes_that_do_not_use_a_matomo_tag
+	 */
+	public function test_update_tracking_code_does_not_ask_matomo_when_the_tag_is_not_used( $track_mode ) {
+		$this->configure_plugin( [ 'track_mode' => $track_mode ] );
+
+		$this->assertFalse( $this->wp_piwik->update_tracking_code( 1 ) );
+		$this->assertSame( [], $this->get_captured_requests() );
+	}
+
+	public function get_track_modes_that_do_not_use_a_matomo_tag() {
+		return [
+			'disabled' => [ 'disabled' ],
+			'manually' => [ 'manually' ],
+		];
+	}
+
+	public function test_update_tracking_code_stores_nothing_when_matomo_returns_no_tag() {
+		$this->answer_with_tracking_code( '' );
+
+		$this->assertFalse( $this->wp_piwik->update_tracking_code( 1 ) );
+
+		$this->assertEmpty( get_option( 'wp-piwik-tracking_code' ) );
+		$this->assertEmpty( get_option( 'wp-piwik-last_tracking_code_update' ) );
+	}
+
+	private function configure_plugin( array $global_options = [], array $options = [] ) {
+		$defaults = [
+			'revision'           => self::INSTALLED_REVISION,
+			'piwik_mode'         => 'http',
+			'piwik_url'          => $this->mock_url(),
+			'piwik_token'        => 'secret-token',
+			'track_mode'         => 'default',
+			// cURL cannot reach the endpoint from inside the test container, and
+			// RestIntegrationTest already covers both transports
+			'http_connection'    => 'fopen',
+			'http_method'        => 'post',
+			'cache'              => false,
+			'connection_timeout' => 15,
+			'auto_site_config'   => false,
+		];
+
+		foreach ( array_merge( $defaults, $global_options ) as $key => $value ) {
+			update_option( 'wp-piwik_global-' . $key, $value );
+		}
+		foreach ( array_merge( [ 'site_id' => 1 ], $options ) as $key => $value ) {
+			update_option( 'wp-piwik-' . $key, $value );
+		}
+
+		$this->wp_piwik = new \WP_Piwik();
+
+		// request keeps its results in static properties, so make sure to clear them
+		// before running a test
+		( new Rest( $this->wp_piwik, \WP_Piwik::get_settings() ) )->reset();
+	}
+
+	/**
+	 * Make the endpoint answer a bulk request with the given tracking code.
+	 */
+	private function answer_with_tracking_code( $tracking_code ) {
+		$this->set_mock_response(
+			[
+				'body' => wp_json_encode(
+					[
+						[ 'value' => $tracking_code ],
+						[ 'value' => '5.0.0' ],
+					]
+				),
+			]
+		);
+	}
+
+	private function get_matomo_tracking_code() {
+		return '<!-- Matomo -->' . "\n"
+			. '<script type="text/javascript">' . "\n"
+			. 'var _paq = window._paq = window._paq || [];' . "\n"
+			. "_paq.push(['trackPageView']);\n"
+			. "(function() {\n"
+			. 'var u="//stats.example.org/";' . "\n"
+			. "_paq.push(['setTrackerUrl', u+'matomo.php']);\n"
+			. "_paq.push(['setSiteId', '1']);\n"
+			. "})();\n"
+			. '</script>' . "\n"
+			. '<noscript><p><img src="//stats.example.org/matomo.php?idsite=1" style="border:0;" alt="" /></p></noscript>';
+	}
+
+	private function get_requested_api_urls() {
+		$urls = [];
+		foreach ( $this->get_captured_requests() as $request ) {
+			$submitted = isset( $request['post']['urls'] ) ? $request['post']['urls'] : [];
+			foreach ( (array) $submitted as $url ) {
+				$urls[] = urldecode( $url );
+			}
+		}
+		return $urls;
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -41,4 +41,5 @@ require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/mock/Plugin.php';
 require_once __DIR__ . '/mock/Settings.php';
+require_once __DIR__ . '/rest/Mock_Matomo_Endpoint.php';
 require_once __DIR__ . '/WP_Piwik_TestCase.php';

--- a/tests/phpunit/rest/Mock_Matomo_Endpoint.php
+++ b/tests/phpunit/rest/Mock_Matomo_Endpoint.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+/**
+ * Drives the mock Matomo endpoint in tests/phpunit/rest/mock.
+ */
+trait Mock_Matomo_Endpoint {
+
+	/**
+	 * @var string
+	 */
+	private $runtime;
+
+	private function set_up_mock_endpoint() {
+		$this->runtime = __DIR__ . '/mock/runtime';
+		if ( ! is_dir( $this->runtime ) ) {
+			mkdir( $this->runtime, 0777, true );
+		}
+
+		// the mock runs as the web server user, the tests as the cli user
+		chmod( $this->runtime, 0777 );
+		$this->write_runtime_file( 'requests.jsonl', '' );
+	}
+
+	private static function is_in_wp_env_environment() {
+		return defined( 'IN_WP_ENV' ) && IN_WP_ENV;
+	}
+
+	private function write_runtime_file( $name, $contents ) {
+		file_put_contents( $this->runtime . '/' . $name, $contents );
+		chmod( $this->runtime . '/' . $name, 0666 );
+	}
+
+	private function set_mock_response( array $response ) {
+		$this->write_runtime_file( 'response.json', wp_json_encode( $response ) );
+	}
+
+	private function get_captured_requests() {
+		$raw = file_get_contents( $this->runtime . '/requests.jsonl' );
+		if ( '' === trim( (string) $raw ) ) {
+			return [];
+		}
+		$requests = [];
+		foreach ( explode( "\n", trim( $raw ) ) as $line ) {
+			if ( '' !== $line ) {
+				$requests[] = json_decode( $line, true );
+			}
+		}
+		return $requests;
+	}
+
+	/**
+	 * @param bool $trailing_slash true to add a trailing slash, false if otherwise.
+	 *
+	 *                             A URL without the trailing slash makes the web
+	 *                             server answer with a 301 to URL with a slash.
+	 */
+	private function mock_url( $trailing_slash = true ) {
+		$host         = getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) ? getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) : 'tests-wordpress';
+		$plugins_path = wp_parse_url( plugins_url(), PHP_URL_PATH );
+		// this file lives in <plugin>/tests/phpunit/rest
+		$plugin_dir = basename( dirname( __DIR__, 3 ) );
+
+		return 'http://' . $host . rtrim( $plugins_path, '/' ) . '/' . $plugin_dir
+			. '/tests/phpunit/rest/mock' . ( $trailing_slash ? '/' : '' );
+	}
+}


### PR DESCRIPTION
### Description

Setting changes require a manual save() call after them, which wp-matomo was not doing. This resulted in tracking code being build from SitesManager on every WP frontend request.

Also includes small refactor tests, a new trait for tests requiring a mock Matomo endpoint.

Fixes MWP-1102

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
