### PR TITLE
various improvements to shortcode parameter handling

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -11,7 +11,7 @@ use WP_Piwik\Widget\Post;
 class WP_Piwik {
 
 	private static $revision_id = 2023092201;
-	private static $version     = '1.1.10';
+	private static $version     = '1.1.11';
 	private static $blog_id;
 	private static $plugin_basename = null;
 	private static $logger;
@@ -1262,19 +1262,25 @@ class WP_Piwik {
 	 *          attribute list
 	 */
 	public function shortcode( $attributes ) {
-		shortcode_atts(
+		// only the attributes listed below reach the widgets. anything else an author
+		// writes is dropped here, so a shortcode cannot smuggle its own parameters.
+		// the defaults are null on purpose: the widgets test their parameters with
+		// isset(), which is false for null, so each widget applies its own
+		// fallback.
+		$attributes       = shortcode_atts(
 			array(
-				'title'    => '',
 				'module'   => 'overview',
-				'period'   => 'day',
-				'date'     => 'yesterday',
-				'limit'    => 10,
-				'width'    => '100%',
-				'height'   => '200px',
-				'idsite'   => '',
-				'language' => 'en',
-				'range'    => false,
-				'key'      => 'sum_daily_nb_uniq_visitors',
+				'title'    => null,
+				'period'   => null,
+				'date'     => null,
+				'limit'    => null,
+				'width'    => null,
+				'height'   => null,
+				'idsite'   => null,
+				'language' => null,
+				'range'    => null,
+				'key'      => null,
+				'url'      => null,
 			),
 			$attributes
 		);

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -1260,32 +1260,11 @@ class WP_Piwik {
 	 *
 	 * @param array $attributes
 	 *          attribute list
+	 * @return string|null
 	 */
 	public function shortcode( $attributes ) {
-		// only the attributes listed below reach the widgets. anything else an author
-		// writes is dropped here, so a shortcode cannot smuggle its own parameters.
-		// the defaults are null on purpose: the widgets test their parameters with
-		// isset(), which is false for null, so each widget applies its own
-		// fallback.
-		$attributes       = shortcode_atts(
-			array(
-				'module'   => 'overview',
-				'title'    => null,
-				'period'   => null,
-				'date'     => null,
-				'limit'    => null,
-				'width'    => null,
-				'height'   => null,
-				'idsite'   => null,
-				'language' => null,
-				'range'    => null,
-				'key'      => null,
-				'url'      => null,
-			),
-			$attributes
-		);
-		$shortcode_object = new \WP_Piwik\Shortcode( $attributes, $this, self::$settings );
-		return $shortcode_object->get();
+		$shortcode = new \WP_Piwik\Shortcode( $this, self::$settings );
+		return $shortcode->render( $attributes );
 	}
 
 	/**

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -290,11 +290,22 @@ class WP_Piwik {
 	private function add_shortcodes() {
 		if ( $this->is_add_shortcode() ) {
 			add_shortcode(
-				'wp-piwik',
+				\WP_Piwik\Shortcode::TAG,
 				array(
 					$this,
 					'shortcode',
 				)
+			);
+			// a reusable block carries its own author, so its shortcodes are resolved
+			// while the block renders rather than with the embedding post's content
+			add_filter(
+				'render_block',
+				array(
+					$this,
+					'render_shortcodes_in_reusable_block',
+				),
+				10,
+				2
 			);
 		}
 	}
@@ -1149,10 +1160,10 @@ class WP_Piwik {
 			$id     = WP_Piwik\Request::register(
 				'Annotations.add',
 				array(
-					'idSite' => $this->get_piwik_site_id(),
-					'date'   => gmdate( 'Y-m-d' ),
-					'note'   => $note,
-				)
+					'date' => gmdate( 'Y-m-d' ),
+					'note' => $note,
+				),
+				$this->get_piwik_site_id()
 			);
 			$result = $this->request( $id );
 			self::$logger->log( 'Add post annotation. ' . $note . ' - ' . wp_json_encode( $result ) );
@@ -1265,6 +1276,11 @@ class WP_Piwik {
 	public function shortcode( $attributes ) {
 		$shortcode = new \WP_Piwik\Shortcode( $this, self::$settings );
 		return $shortcode->render( $attributes );
+	}
+
+	public function render_shortcodes_in_reusable_block( $block_content, $block ) {
+		$shortcode = new \WP_Piwik\Shortcode( $this, self::$settings );
+		return $shortcode->render_reusable_block( $block_content, $block );
 	}
 
 	/**
@@ -1385,10 +1401,10 @@ class WP_Piwik {
 		$id         = WP_Piwik\Request::register(
 			'SitesManager.updateSite',
 			array(
-				'idSite'   => $site_id,
 				'urls'     => $is_current ? get_bloginfo( 'url' ) : get_blog_details( $blog_id )->siteurl,
 				'siteName' => $is_current ? get_bloginfo( 'name' ) : get_blog_details( $blog_id )->blogname,
-			)
+			),
+			$site_id
 		);
 		$this->request( $id );
 		self::$logger->log( 'Update Matomo site: WordPress site ' . ( $is_current ? get_bloginfo( 'url' ) : get_blog_details( $blog_id )->siteurl ) );
@@ -1413,13 +1429,13 @@ class WP_Piwik {
 		$id   = WP_Piwik\Request::register(
 			'SitesManager.getJavascriptTag',
 			array(
-				'idSite'          => $site_id,
 				'mergeSubdomains' => self::$settings->get_global_option( 'track_across' ) ? 1 : 0,
 				'mergeAliasUrls'  => self::$settings->get_global_option( 'track_across_alias' ) ? 1 : 0,
 				'disableCookies'  => self::$settings->get_global_option( 'disable_cookies' ) ? 1 : 0,
 				'crossDomain'     => self::$settings->get_global_option( 'track_crossdomain_linking' ) ? 1 : 0,
 				'trackNoScript'   => 1,
-			)
+			),
+			$site_id
 		);
 		$code = $this->request( $id );
 		if ( is_array( $code ) && isset( $code['value'] ) ) {

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -278,7 +278,23 @@ class Settings extends \WP_Piwik\Admin {
 
 			$this->show_input( 'plugin_display_name', __( 'WP-Matomo display name', 'wp-piwik' ), __( 'Plugin name shown in WordPress.', 'wp-piwik' ) );
 
-			$this->show_checkbox( 'shortcodes', __( 'Enable shortcodes', 'wp-piwik' ), __( 'Enable shortcodes in post or page content.', 'wp-piwik' ) );
+			$this->show_checkbox(
+				'shortcodes',
+				__( 'Enable shortcodes', 'wp-piwik' ),
+				__( 'Enable shortcodes in post or page content.', 'wp-piwik' ),
+				false,
+				'',
+				true,
+				'jQuery(\'tr.wp-piwik-shortcode-option\').toggleClass(\'hidden\', !this.checked);'
+			);
+
+			$this->show_checkbox(
+				'shortcode_author_check',
+				__( 'Restrict shortcodes to authorized authors', 'wp-piwik' ),
+				__( 'Only show the statistics of a shortcode if the author of the post containing it is allowed to see the statistics (see &raquo;Display stats to&laquo; above). Note: the opt-out shortcode is always displayed.', 'wp-piwik' ),
+				! self::$settings->get_global_option( 'shortcodes' ),
+				'wp-piwik-shortcode-option'
+			);
 
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo $submit_button;

--- a/classes/WP_Piwik/Request.php
+++ b/classes/WP_Piwik/Request.php
@@ -111,10 +111,15 @@ abstract class Request {
 
 	protected function get_url_params( $config ) {
 		$params = [
-			'method' => $config['method'],
 			'idSite' => self::$settings->get_option( 'site_id' ),
 		];
-		$params = array_merge( $params, $config['parameter'] );
+		// method is merged last, so a parameter can never redefine which API
+		// method runs
+		$params = array_merge(
+			$params,
+			$config['parameter'],
+			[ 'method' => $config['method'] ]
+		);
 		return $params;
 	}
 

--- a/classes/WP_Piwik/Request.php
+++ b/classes/WP_Piwik/Request.php
@@ -34,11 +34,24 @@ abstract class Request {
 		self::$piwik_version = null;
 	}
 
-	public static function register( $method, $parameter ) {
+	/**
+	 * Queue a Matomo API request
+	 *
+	 * @param string   $method
+	 *          Matomo API method to call
+	 * @param array    $parameter
+	 *          request parameters. an idSite entry is ignored: the site is not
+	 *          selectable through a parameter, pass $id_site instead
+	 * @param int|null $id_site
+	 *          Matomo site to query, null to use the one this blog is configured with
+	 * @return string request id to hand to perform()
+	 */
+	public static function register( $method, $parameter, $id_site = null ) {
 		if ( 'API.getPiwikVersion' === $method ) {
 			$id = 'global.getPiwikVersion';
 		} else {
-			$id = 'method=' . $method . self::parameter_to_string( $parameter );
+			$id = 'method=' . $method . self::parameter_to_string( $parameter )
+				. ( null !== $id_site ? '&idSite=' . $id_site : '' );
 		}
 		if (
 			in_array( $method, array( 'API.getPiwikVersion', 'SitesManager.getJavascriptTag', 'SitesManager.getSitesWithAtLeastViewAccess', 'SitesManager.getSitesIdFromSiteUrl', 'SitesManager.addSite', 'SitesManager.updateSite', 'SitesManager.getSitesWithAtLeastViewAccess' ), true ) ||
@@ -53,12 +66,13 @@ abstract class Request {
 			self::$is_cacheable[ $id ] = false;
 		} else {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-			self::$is_cacheable[ $id ] = $method . '-' . serialize( $parameter );
+			self::$is_cacheable[ $id ] = $method . ( null !== $id_site ? '-' . $id_site : '' ) . '-' . serialize( $parameter );
 		}
 		if ( ! isset( self::$requests[ $id ] ) ) {
 			self::$requests[ $id ] = array(
 				'method'    => $method,
 				'parameter' => $parameter,
+				'id_site'   => $id_site,
 			);
 		}
 		return $id;
@@ -110,17 +124,17 @@ abstract class Request {
 	}
 
 	protected function get_url_params( $config ) {
-		$params = [
-			'idSite' => self::$settings->get_option( 'site_id' ),
-		];
-		// method is merged last, so a parameter can never redefine which API
-		// method runs
-		$params = array_merge(
-			$params,
+		$id_site = isset( $config['id_site'] )
+			? $config['id_site']
+			: self::$settings->get_option( 'site_id' );
+
+		return array_merge(
 			$config['parameter'],
-			[ 'method' => $config['method'] ]
+			[
+				'idSite' => $id_site,
+				'method' => $config['method'],
+			]
 		);
-		return $params;
 	}
 
 	protected function unserialize( $str ) {

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -86,6 +86,7 @@ class Settings {
 		'plugin_display_name'         => 'Connect Matomo',
 		'piwik_shortcut'              => false,
 		'shortcodes'                  => false,
+		'shortcode_author_check'      => true,
 		// User settings: Tracking configuration
 		'track_mode'                  => 'disabled',
 		'track_codeposition'          => 'footer',

--- a/classes/WP_Piwik/Shortcode.php
+++ b/classes/WP_Piwik/Shortcode.php
@@ -9,6 +9,8 @@ class Shortcode {
 
 	const TAG = 'wp-piwik';
 
+	const MAX_BLOCK_PASSES = 10;
+
 	private $available = array(
 		'opt-out'  => 'OptOut',
 		'post'     => 'Post',
@@ -117,14 +119,35 @@ class Shortcode {
 			$shortcode_tags = array( self::TAG => $all_tags[ self::TAG ] );
 			$post           = $reusable_block;
 
-			$block_content = do_shortcode( $block_content );
+			// do_shortcode() peels one bracket level off [[wp-piwik]] rather than
+			// expanding it, so a single pass would hand the tag on to the content wide
+			// pass, which authorizes against the embedding post instead. keep expanding
+			// while there is something here of ours left to expand.
+			$passes = 0;
+			do {
+				$before        = $block_content;
+				$block_content = do_shortcode( $block_content );
+			} while (
+				$before !== $block_content
+				&& false !== strpos( $block_content, '[' . self::TAG )
+				&& ++$passes < self::MAX_BLOCK_PASSES
+			);
 		} finally {
 			$shortcode_tags = $all_tags;
 			$post           = $saved_post;
 		}
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		return $block_content;
+		return $this->disarm_leftover_tags( $block_content );
+	}
+
+	private function disarm_leftover_tags( $block_content ) {
+		// &#091; and not &#91;, which do_shortcode() turns back into a bracket
+		return preg_replace(
+			'/\[(?=\[*' . preg_quote( self::TAG, '/' ) . '(?![\w-]))/',
+			'&#091;',
+			$block_content
+		);
 	}
 
 	/**
@@ -250,6 +273,14 @@ class Shortcode {
 	 * @return bool true if the URL is a post on this site the author may read
 	 */
 	private function is_url_allowed( $url, $author_id ) {
+		// url_to_postid() below looks for ?p= anywhere in the string it is given, ahead
+		// of stripping the fragment itself, so a fragment left on here could name a
+		// post other than the one the path names and authorize against that instead.
+		$fragment_at = strpos( $url, '#' );
+		if ( false !== $fragment_at ) {
+			$url = substr( $url, 0, $fragment_at );
+		}
+
 		if ( ! $this->is_url_on_this_site( $url ) ) {
 			return false;
 		}

--- a/classes/WP_Piwik/Shortcode.php
+++ b/classes/WP_Piwik/Shortcode.php
@@ -2,6 +2,9 @@
 
 namespace WP_Piwik;
 
+/**
+ * Renders the [wp-piwik] shortcode
+ */
 class Shortcode {
 
 	private $available = array(
@@ -10,25 +13,271 @@ class Shortcode {
 		'overview' => 'Overview',
 	);
 
-	private $content;
+	/**
+	 * Attributes a shortcode may use, and their defaults
+	 *
+	 * Only the attributes listed here reach the widgets. Anything else an author
+	 * writes is dropped.
+	 *
+	 * The defaults are null on purpose: the widgets test their parameters with
+	 * isset(), so each widget applies its own fallback.
+	 *
+	 * @var array
+	 */
+	private $supported = array(
+		'module'   => 'overview',
+		'title'    => null,
+		'period'   => null,
+		'date'     => null,
+		'limit'    => null,
+		'width'    => null,
+		'height'   => null,
+		'idsite'   => null,
+		'language' => null,
+		'range'    => null,
+		'key'      => null,
+		'url'      => null,
+	);
 
 	/**
-	 * @param array     $attributes
+	 * @var \WP_Piwik
+	 */
+	private $wp_piwik;
+
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
 	 * @param \WP_Piwik $wp_piwik
 	 * @param Settings  $settings
 	 */
-	public function __construct( $attributes, $wp_piwik, $settings ) {
-		$wp_piwik->log( 'Check requested shortcode widget ' . $attributes['module'] );
-		if ( isset( $attributes['module'] ) && isset( $this->available[ $attributes['module'] ] ) ) {
-			$wp_piwik->log( 'Add shortcode widget ' . $this->available[ $attributes['module'] ] );
-			$class  = '\\WP_Piwik\\Widget\\' . $this->available[ $attributes['module'] ];
-			$widget = new $class( $wp_piwik, $settings, null, null, null, $attributes, true );
-			$widget->show();
-			$this->content = $widget->get();
-		}
+	public function __construct( $wp_piwik, $settings ) {
+		$this->wp_piwik = $wp_piwik;
+		$this->settings = $settings;
 	}
 
-	public function get() {
-		return $this->content;
+	/**
+	 * Execute the shortcode
+	 *
+	 * @param array|string $attributes
+	 *          attribute list as WordPress passes it, an empty string if the
+	 *          shortcode was written without any attribute
+	 * @return string|null shortcode output, null if no widget matched
+	 */
+	public function render( $attributes ) {
+		$attributes = shortcode_atts(
+			$this->supported,
+			$attributes
+		);
+		$attributes = $this->sanitize_attributes( $attributes );
+
+		// authorize before any API request is sent
+		$denial = $this->check_authorization( $attributes );
+		if ( null !== $denial ) {
+			return $denial;
+		}
+
+		return $this->render_widget( $attributes );
+	}
+
+	/**
+	 * Let the widget matching the requested module produce the output
+	 *
+	 * @param array $attributes
+	 *          attribute list, already reduced to the supported attributes
+	 * @return string|null widget output, null if the module is unknown
+	 */
+	private function render_widget( $attributes ) {
+		$this->wp_piwik->log( 'Check requested shortcode widget ' . $attributes['module'] );
+		if ( isset( $attributes['module'] ) && isset( $this->available[ $attributes['module'] ] ) ) {
+			$this->wp_piwik->log( 'Add shortcode widget ' . $this->available[ $attributes['module'] ] );
+			$class  = '\\WP_Piwik\\Widget\\' . $this->available[ $attributes['module'] ];
+			$widget = new $class( $this->wp_piwik, $this->settings, null, null, null, $attributes, true );
+			$widget->show();
+			return $widget->get();
+		}
+		return null;
+	}
+
+	/**
+	 * Reject shortcode attribute values Matomo would not accept anyway.
+	 *
+	 * @param array $attributes attribute list, already reduced to the supported attributes
+	 * @return array attribute list with unusable values removed
+	 */
+	private function sanitize_attributes( $attributes ) {
+		if (
+			null !== $attributes['period']
+			&& ! in_array( $attributes['period'], array( 'day', 'week', 'month', 'year', 'range' ), true )
+		) {
+			$attributes['period'] = null;
+		}
+		if (
+			null !== $attributes['date']
+			&& ! preg_match( '/^(today|yesterday|(last|previous)\d{1,4}|\d{4}-\d{2}-\d{2}(,\d{4}-\d{2}-\d{2})?)$/', $attributes['date'] )
+		) {
+			$attributes['date'] = null;
+		}
+		if (
+			null !== $attributes['language']
+			&& ! preg_match( '/^[a-z]{2,3}(-[A-Za-z]+)?$/', $attributes['language'] )
+		) {
+			$attributes['language'] = null;
+		}
+		return $attributes;
+	}
+
+	/**
+	 * Decide whether a shortcode may ask Matomo for data
+	 *
+	 * @param array $attributes
+	 *          attribute list, already reduced to the supported attributes
+	 * @return string|null output to return instead of the widget, or null if the
+	 *          shortcode may run
+	 */
+	private function check_authorization( $attributes ) {
+		// the opt-out iframe performs no API request and has to stay reachable by
+		// anonymous visitors, so it is never gated.
+		if ( 'opt-out' === $attributes['module'] ) {
+			return null;
+		}
+
+		$post       = get_post();
+		$post       = $post instanceof \WP_Post ? $post : null;
+		$author_id  = null !== $post ? (int) $post->post_author : 0;
+		$authorized = true;
+		$reason     = 'filtered';
+
+		if (
+			$this->settings->get_global_option( 'shortcode_author_check' )
+			&& null !== $post
+			&& ! user_can( $author_id, 'wp-piwik_read_stats' )
+		) {
+			$authorized = false;
+			$reason     = 'author';
+		}
+		// $post === null means the shortcode text comes from a theme template, a sidebar
+		// widget or WP-CLI. editing any of those needs capabilities well above
+		// wp-piwik_read_stats, so there is nobody left to authorize and the shortcode
+		// is allowed through. sites that want this closed can use the filter below.
+
+		// extra check for the "post" shortcode type
+		if ( $authorized && 'post' === $attributes['module'] ) {
+			if ( null === $post ) {
+				$authorized = false;
+				$reason     = 'no_post';
+			} elseif (
+				null !== $attributes['url']
+				&& ! $this->is_url_allowed( $attributes['url'], $author_id )
+			) {
+				$authorized = false;
+				$reason     = 'url';
+			}
+		}
+
+		/**
+		 * Filter whether a shortcode may request data from Matomo. The hook can return
+		 * a WP_Error to deny with a reason.
+		 *
+		 * @param bool          $authorized whether the shortcode may run
+		 * @param array         $attributes shortcode attributes
+		 * @param \WP_Post|null $post       post the shortcode is rendered in, if any
+		 */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, WordPress.NamingConventions.ValidHookName.UseUnderscores
+		$authorized = apply_filters( 'wp-piwik_shortcode_authorized', $authorized, $attributes, $post );
+		if ( $authorized instanceof \WP_Error ) {
+			$reason     = $authorized;
+			$authorized = false;
+		}
+
+		return $authorized ? null : $this->build_denial_output( $reason );
+	}
+
+	/**
+	 * Check whether a post shortcode may report on a URL
+	 *
+	 * @param string $url
+	 *          URL requested by the shortcode's url attribute
+	 * @param int    $author_id
+	 *          author of the post containing the shortcode
+	 * @return bool true if the URL is a post on this site the author may read
+	 */
+	private function is_url_allowed( $url, $author_id ) {
+		if ( ! $this->is_url_on_this_site( $url ) ) {
+			return false;
+		}
+		// this also rules out /wp-admin/, archives and anything else that is not a
+		// post, so the url attribute can only ever name another post on this site.
+		$post_id = url_to_postid( $url );
+		if ( ! $post_id ) {
+			return false;
+		}
+		return user_can( $author_id, 'read_post', $post_id );
+	}
+
+	/**
+	 * Check whether a URL points at this site
+	 *
+	 * @param string $url
+	 *          URL to check
+	 * @return bool
+	 */
+	private function is_url_on_this_site( $url ) {
+		$target = wp_parse_url( $url );
+		$home   = wp_parse_url( home_url( '/' ) );
+		if ( empty( $target ) || empty( $home['host'] ) ) {
+			return false;
+		}
+		if ( ! empty( $target['host'] ) && strtolower( $target['host'] ) !== strtolower( $home['host'] ) ) {
+			return false;
+		}
+		$home_path   = isset( $home['path'] ) ? $home['path'] : '/';
+		$target_path = isset( $target['path'] ) ? $target['path'] : '/';
+		return 0 === strpos( $target_path, $home_path );
+	}
+
+	/**
+	 * Build the output of a shortcode that was not allowed to run
+	 *
+	 * @param string|\WP_Error $reason
+	 *          which check rejected the shortcode: author, no_post, url or filtered
+	 * @return string output to render in place of the widget
+	 */
+	private function build_denial_output( $reason ) {
+		switch ( $reason ) {
+			case 'author':
+				$message = __( 'the author of this post is not allowed to see the statistics.', 'wp-piwik' );
+				break;
+			case 'no_post':
+				$message = __( 'the post module can only report on a post, and this shortcode was not rendered within one.', 'wp-piwik' );
+				break;
+			case 'url':
+				$message = __( 'its url attribute does not name a post on this site the author is allowed to read.', 'wp-piwik' );
+				break;
+			default:
+				if ( $reason instanceof \WP_Error ) {
+					$message = $reason->get_error_message();
+					$reason  = 'filtered';
+				} else {
+					$message = __( 'the wp-piwik_shortcode_authorized filter rejected it.', 'wp-piwik' );
+				}
+				break;
+		}
+		$this->wp_piwik->log( 'Shortcode blocked (' . $reason . '): ' . $message );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return '';
+		}
+		return '<p class="wp-piwik-shortcode-denied"><em>'
+			. esc_html(
+				sprintf(
+					/* translators: %1$s: plugin display name, %2$s: sentence fragment explaining which check rejected the shortcode */
+					__( '%1$s: this shortcode was not rendered, because %2$s', 'wp-piwik' ),
+					$this->settings->get_not_empty_global_option( 'plugin_display_name' ),
+					$message
+				)
+			)
+			. '</em></p>';
 	}
 }

--- a/classes/WP_Piwik/Shortcode.php
+++ b/classes/WP_Piwik/Shortcode.php
@@ -7,6 +7,8 @@ namespace WP_Piwik;
  */
 class Shortcode {
 
+	const TAG = 'wp-piwik';
+
 	private $available = array(
 		'opt-out'  => 'OptOut',
 		'post'     => 'Post',
@@ -80,6 +82,49 @@ class Shortcode {
 		}
 
 		return $this->render_widget( $attributes );
+	}
+
+	/**
+	 * Resolve the shortcodes of a reusable block against the block's own author
+	 * instead of the embedding post's author. Must be done before the content-wide
+	 * do_shortcode pass expands it in order to get the author of the block (this
+	 * information is lost afterward).
+	 *
+	 * @param string $block_content rendered block markup
+	 * @param array  $block         parsed block
+	 * @return string block markup with this plugin's shortcodes resolved
+	 */
+	public function render_reusable_block( $block_content, $block ) {
+		global $shortcode_tags, $post;
+
+		// only run the gate if we need to (ie, the block has the shortcode in it)
+		if ( empty( $block['blockName'] ) || 'core/block' !== $block['blockName'] || empty( $block['attrs']['ref'] ) ) {
+			return $block_content;
+		}
+		if ( ! isset( $shortcode_tags[ self::TAG ] ) || false === strpos( $block_content, '[' . self::TAG ) ) {
+			return $block_content;
+		}
+		$reusable_block = get_post( (int) $block['attrs']['ref'] );
+		if ( ! $reusable_block instanceof \WP_Post ) {
+			return $block_content;
+		}
+
+		$all_tags   = $shortcode_tags;
+		$saved_post = $post;
+		// the post is swapped because that is where the gate reads its subject from.
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+		try {
+			$shortcode_tags = array( self::TAG => $all_tags[ self::TAG ] );
+			$post           = $reusable_block;
+
+			$block_content = do_shortcode( $block_content );
+		} finally {
+			$shortcode_tags = $all_tags;
+			$post           = $saved_post;
+		}
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		return $block_content;
 	}
 
 	/**
@@ -181,9 +226,9 @@ class Shortcode {
 		 * Filter whether a shortcode may request data from Matomo. The hook can return
 		 * a WP_Error to deny with a reason.
 		 *
-		 * @param bool          $authorized whether the shortcode may run
-		 * @param array         $attributes shortcode attributes
-		 * @param \WP_Post|null $post       post the shortcode is rendered in, if any
+		 * @param bool|\WP_Error $authorized whether the shortcode may run
+		 * @param array          $attributes shortcode attributes
+		 * @param \WP_Post|null  $post       post the shortcode is rendered in, if any
 		 */
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound, WordPress.NamingConventions.ValidHookName.UseUnderscores
 		$authorized = apply_filters( 'wp-piwik_shortcode_authorized', $authorized, $attributes, $post );
@@ -233,9 +278,24 @@ class Shortcode {
 		if ( ! empty( $target['host'] ) && strtolower( $target['host'] ) !== strtolower( $home['host'] ) ) {
 			return false;
 		}
+		if ( ! $this->is_same_port( $target, $home ) ) {
+			return false;
+		}
 		$home_path   = isset( $home['path'] ) ? $home['path'] : '/';
 		$target_path = isset( $target['path'] ) ? $target['path'] : '/';
 		return 0 === strpos( $target_path, $home_path );
+	}
+
+	private function is_same_port( $target, $home ) {
+		$target_port = isset( $target['port'] ) ? (int) $target['port'] : null;
+		$home_port   = isset( $home['port'] ) ? (int) $home['port'] : null;
+		if ( $target_port === $home_port ) {
+			return true;
+		}
+		$stated_port = null === $home_port ? $target_port : $home_port;
+		return null === $target_port || null === $home_port
+			? in_array( $stated_port, array( 80, 443 ), true )
+			: false;
 	}
 
 	/**

--- a/classes/WP_Piwik/Widget.php
+++ b/classes/WP_Piwik/Widget.php
@@ -75,7 +75,9 @@ abstract class Widget {
 				$this->api_id [ $method ] = Request::register( $method, $this->parameter );
 				self::$wp_piwik->log( 'Register request: ' . $this->api_id [ $method ] );
 			}
-		} else {
+		} elseif ( '' !== $this->method ) {
+			// a widget without a method performs no API request, so it must not
+			// queue one, or it will affect the next bulk api request call.
 			$this->api_id [ $this->method ] = Request::register( $this->method, $this->parameter );
 			self::$wp_piwik->log( 'Register request: ' . $this->api_id [ $this->method ] );
 		}

--- a/classes/WP_Piwik/Widget.php
+++ b/classes/WP_Piwik/Widget.php
@@ -70,15 +70,22 @@ abstract class Widget {
 		$this->is_shortcode = $is_shortcode;
 		$prefix             = ( 'dashboard' === $this->page_id ? self::$settings->get_global_option( 'plugin_display_name' ) . ' - ' : '' );
 		$this->configure( $prefix, $params );
+		// the site a widget reports on is not a request parameter, so hand it to
+		// register() separately
+		$id_site = null;
+		if ( isset( $this->parameter['idSite'] ) ) {
+			$id_site = $this->parameter['idSite'];
+			unset( $this->parameter['idSite'] );
+		}
 		if ( is_array( $this->method ) ) {
 			foreach ( $this->method as $method ) {
-				$this->api_id [ $method ] = Request::register( $method, $this->parameter );
+				$this->api_id [ $method ] = Request::register( $method, $this->parameter, $id_site );
 				self::$wp_piwik->log( 'Register request: ' . $this->api_id [ $method ] );
 			}
 		} elseif ( '' !== $this->method ) {
 			// a widget without a method performs no API request, so it must not
 			// queue one, or it will affect the next bulk api request call.
-			$this->api_id [ $this->method ] = Request::register( $this->method, $this->parameter );
+			$this->api_id [ $this->method ] = Request::register( $this->method, $this->parameter, $id_site );
 			self::$wp_piwik->log( 'Register request: ' . $this->api_id [ $this->method ] );
 		}
 		if ( $this->is_shortcode ) {

--- a/classes/WP_Piwik/Widget/OptOut.php
+++ b/classes/WP_Piwik/Widget/OptOut.php
@@ -7,7 +7,12 @@ class OptOut extends \WP_Piwik\Widget {
 	public $class_name = __CLASS__;
 
 	protected function configure( $prefix = '', $params = array() ) {
-		$this->parameter = $params;
+		$this->parameter = array(
+			'width'    => isset( $params['width'] ) ? $params['width'] : '100%',
+			'height'   => isset( $params['height'] ) ? $params['height'] : '200px',
+			'idsite'   => isset( $params['idsite'] ) ? $params['idsite'] : '',
+			'language' => isset( $params['language'] ) ? $params['language'] : 'en',
+		);
 	}
 
 	public function show() {
@@ -26,10 +31,12 @@ class OptOut extends \WP_Piwik\Widget {
 				$piwik_url = self::$settings->get_global_option( 'piwik_url' );
 				break;
 		}
-		$width    = ( isset( $this->parameter['width'] ) ? rawurlencode( $this->parameter['width'] ) : '' );
-		$height   = ( isset( $this->parameter['height'] ) ? rawurlencode( $this->parameter['height'] ) : '' );
-		$idsite   = ( isset( $this->parameter['idsite'] ) ? 'idsite=' . (int) $this->parameter['idsite'] . '&' : '' );
-		$language = ( isset( $this->parameter['language'] ) ? rawurlencode( $this->parameter['language'] ) : 'en' );
+		// width and height end up in HTML attributes, where esc_attr() is the
+		// right encoding; idsite and language end up in the iframe URL
+		$width    = $this->parameter['width'];
+		$height   = $this->parameter['height'];
+		$idsite   = ( '' !== $this->parameter['idsite'] ? 'idsite=' . (int) $this->parameter['idsite'] . '&' : '' );
+		$language = rawurlencode( $this->parameter['language'] );
 		$this->out( '<iframe frameborder="no" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" src="' . esc_attr( $piwik_url . 'index.php?module=CoreAdminHome&action=optOut&' . $idsite . 'language=' . $language ) . '"></iframe>' );
 	}
 }

--- a/classes/WP_Piwik/Widget/Post.php
+++ b/classes/WP_Piwik/Widget/Post.php
@@ -8,13 +8,21 @@ class Post extends \WP_Piwik\Widget {
 
 	protected function configure( $prefix = '', $params = array() ) {
 		global $post;
+		$page_url = isset( $params['url'] ) ? $params['url'] : null;
+		if ( null === $page_url && $post instanceof \WP_Post ) {
+			$page_url = get_permalink( $post->ID );
+		}
+		if ( empty( $page_url ) ) {
+			// no page means nothing to report on
+			return;
+		}
 		$time_settings   = $this->get_time_settings();
 		$this->parameter = array(
 			'idSite'      => self::$wp_piwik->get_piwik_site_id( $this->blog_id ),
 			'period'      => isset( $params['period'] ) ? $params['period'] : $time_settings['period'],
 			'date'        => isset( $params['date'] ) ? $params['date'] : $time_settings['date'],
 			'key'         => isset( $params['key'] ) ? $params['key'] : null,
-			'pageUrl'     => isset( $params['url'] ) ? $params['url'] : get_permalink( $post->ID ),
+			'pageUrl'     => $page_url,
 			'description' => $time_settings['description'],
 		);
 		$this->title     = $prefix . esc_html__( 'Overview', 'wp-piwik' ) . ' (' . $this->parameter['date'] . ')';
@@ -22,6 +30,10 @@ class Post extends \WP_Piwik\Widget {
 	}
 
 	public function show() {
+		if ( ! isset( $this->api_id[ $this->method ] ) ) {
+			// configure() found no page to report on
+			return;
+		}
 		$response = self::$wp_piwik->request( $this->api_id[ $this->method ] );
 		if ( ! empty( $response['result'] ) && 'error' === $response['result'] ) {
 			echo '<strong>' . esc_html__( 'Piwik error', 'wp-piwik' ) . ':</strong> ' . esc_html( $response['message'] );

--- a/readme.txt
+++ b/readme.txt
@@ -3,14 +3,14 @@
 Contributors: Braekling
 Requires at least: 5.0
 Tested up to: 7.0.0
-Stable tag: 1.1.10
+Stable tag: 1.1.11
 Tags: matomo, tracking, statistics, stats, analytics
 
 Adds Matomo (former Piwik) statistics to your WordPress dashboard and is also able to add the Matomo Tracking Code to your blog.
 
 == Description ==
 
-**Version 1.1.7 includes a security related fix, it is highly recommended to update to this or a later version.**
+**Version 1.1.11 includes a security related fix, it is highly recommended to update to this or a later version.**
 
 If you are not yet using Matomo On-Premise, Matomo Cloud or hosting your own instance of Matomo, please use the [Matomo for WordPress plugin](https://wordpress.org/plugins/matomo/).
 
@@ -145,6 +145,11 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 5. Matomo: Here you'll find your auth token.
 
 == Changelog ==
+
+= 1.1.11 =
+* Security: shortcodes no longer pass unknown attributes on to Matomo.
+* Bug fix: [wp-piwik] without attributes shows the overview.
+* Bug fix: the opt-out shortcode applies its documented default size of 100% by 200px when width and height are omitted, and no longer URL encodes them into the iframe HTML attributes.
 
 = 1.1.10 =
 * Update tracker proxy to latest version.

--- a/readme.txt
+++ b/readme.txt
@@ -41,8 +41,8 @@ Shows overview table like WP-Matomo's overview dashboard. See Matomo API documen
     [wp-piwik module="opt-out" language="en" width="100%" height="200px"]
 Shows the Matomo opt-out Iframe. You can change the Iframe's language by the language attribute (e.g. de for German language) and its width and height using the corresponding attributes.
 
-    [wp-piwik module="post" range="last30" key="sum_daily_nb_uniq_visitors"]
-Shows the chosen keys value related to the current post. You can define a range (format: lastN, previousN or YYYY-MM-DD,YYYY-MM-DD) and the desired value's key (e.g., sum_daily_nb_uniq_visitors, nb_visits or nb_hits - for details see Matomo's API method Actions.getPageUrl using a range).
+    [wp-piwik module="post" period="range" date="last30" key="sum_daily_nb_uniq_visitors"]
+Shows the chosen keys value related to the current post. You can define a date (format: lastN, previousN, today, yesterday, YYYY-MM-DD or YYYY-MM-DD,YYYY-MM-DD) and the desired value's key (e.g., sum_daily_nb_uniq_visitors, nb_visits or nb_hits - for details see Matomo's API method Actions.getPageUrl using a range). The optional url attribute reports on another post of this site instead of the current one; it is only accepted if it resolves to a posts author of the containing post is allowed to read.
 
     [wp-piwik]
 is equal to *[wp-piwik module="overview" title="" period="day" date="yesterday"]*.
@@ -147,6 +147,10 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 == Changelog ==
 
 = 1.1.11 =
+* Security: the overview and post shortcodes are no longer rendered if the author of the post containing them is not allowed to see the statistics.
+* Security: the url attribute of the post shortcode is now restricted to posts of the author is allowed to read.
+* Security: shortcodes ignore period, date and language attributes Matomo would not accept, and fall back to their default instead.
+* Bug fix: the post shortcode no longer triggers a request when there is no post to report on.
 * Security: shortcodes no longer pass unknown attributes on to Matomo.
 * Bug fix: [wp-piwik] without attributes shows the overview.
 * Bug fix: the opt-out shortcode applies its documented default size of 100% by 200px when width and height are omitted, and no longer URL encodes them into the iframe HTML attributes.

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ Shows overview table like WP-Matomo's overview dashboard. See Matomo API documen
 Shows the Matomo opt-out Iframe. You can change the Iframe's language by the language attribute (e.g. de for German language) and its width and height using the corresponding attributes.
 
     [wp-piwik module="post" period="range" date="last30" key="sum_daily_nb_uniq_visitors"]
-Shows the chosen keys value related to the current post. You can define a date (format: lastN, previousN, today, yesterday, YYYY-MM-DD or YYYY-MM-DD,YYYY-MM-DD) and the desired value's key (e.g., sum_daily_nb_uniq_visitors, nb_visits or nb_hits - for details see Matomo's API method Actions.getPageUrl using a range). The optional url attribute reports on another post of this site instead of the current one; it is only accepted if it resolves to a posts author of the containing post is allowed to read.
+Shows the chosen keys value related to the current post. You can define a date (format: lastN, previousN, today, yesterday, YYYY-MM-DD or YYYY-MM-DD,YYYY-MM-DD) and the desired value's key (e.g., sum_daily_nb_uniq_visitors, nb_visits or nb_hits - for details see Matomo's API method Actions.getPageUrl using a range). The optional url attribute reports on another post of this site instead of the current one; it is only accepted if it resolves to a post the author of the containing post is allowed to read.
 
     [wp-piwik]
 is equal to *[wp-piwik module="overview" title="" period="day" date="yesterday"]*.
@@ -148,7 +148,7 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 
 = 1.1.11 =
 * Security: the overview and post shortcodes are no longer rendered if the author of the post containing them is not allowed to see the statistics.
-* Security: the url attribute of the post shortcode is now restricted to posts of the author is allowed to read.
+* Security: the url attribute of the post shortcode is now restricted to posts the author is allowed to read.
 * Security: shortcodes ignore period, date and language attributes Matomo would not accept, and fall back to their default instead.
 * Bug fix: the post shortcode no longer triggers a request when there is no post to report on.
 * Security: shortcodes no longer pass unknown attributes on to Matomo.

--- a/tests/phpunit/OptOutTest.php
+++ b/tests/phpunit/OptOutTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request;
+use WP_Piwik\Widget\OptOut;
+
+class OptOut_Test_Request extends Request {
+
+	protected function request( $id ) {
+	}
+
+	public static function get_registered() {
+		return self::$requests;
+	}
+}
+
+class OptOutTest extends WP_Piwik_TestCase {
+
+	public function test_construct_should_register_no_api_request() {
+		$this->create_opt_out( array( 'language' => 'de' ) );
+
+		$this->assertSame( array(), OptOut_Test_Request::get_registered() );
+	}
+
+	public function test_show_should_render_the_documented_default_size() {
+		$output = $this->create_opt_out( array() )->get();
+
+		// readme.txt documents 100% and 200px as the defaults
+		$this->assertStringContainsString( 'width="100%"', $output );
+		$this->assertStringContainsString( 'height="200px"', $output );
+	}
+
+	public function test_show_should_not_url_encode_the_size() {
+		$output = $this->create_opt_out( array( 'width' => '100%' ) )->get();
+
+		$this->assertStringNotContainsString( '100%25', $output );
+	}
+
+	public function test_show_should_use_the_supplied_language_and_site_id() {
+		$output = $this->create_opt_out(
+			array(
+				'language' => 'de',
+				'idsite'   => '9',
+			)
+		)->get();
+
+		$this->assertStringContainsString( 'idsite=9', $output );
+		$this->assertStringContainsString( 'language=de', $output );
+	}
+
+	public function test_show_should_omit_the_site_id_when_none_was_given() {
+		$output = $this->create_opt_out( array() )->get();
+
+		$this->assertStringNotContainsString( 'idsite=', $output );
+		$this->assertStringContainsString( 'language=en', $output );
+	}
+
+	public function test_show_should_point_the_iframe_at_the_configured_matomo() {
+		$output = $this->create_opt_out( array() )->get();
+
+		$this->assertStringContainsString( 'src="https://matomo.example.org/index.php?module=CoreAdminHome', $output );
+	}
+
+	private function create_opt_out( array $params ) {
+		$settings = $this->create_settings(
+			array(
+				'piwik_mode' => 'http',
+				'piwik_url'  => 'https://matomo.example.org/',
+			),
+			array( 'site_id' => 7 )
+		);
+
+		$request = new OptOut_Test_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$request->reset();
+
+		$widget = new OptOut( new \WP_Piwik_Test_Mock_Plugin(), $settings, null, null, null, $params, true );
+		$widget->show();
+
+		return $widget;
+	}
+}

--- a/tests/phpunit/RequestTest.php
+++ b/tests/phpunit/RequestTest.php
@@ -263,7 +263,7 @@ class RequestTest extends WP_Piwik_TestCase {
 			]
 		);
 
-		$this->assertSame( 'idSite=7&period=day&date=today&method=VisitsSummary.get', $url );
+		$this->assertSame( 'period=day&date=today&idSite=7&method=VisitsSummary.get', $url );
 	}
 
 	public function test_build_url_should_ignore_a_method_supplied_as_a_parameter() {
@@ -278,10 +278,12 @@ class RequestTest extends WP_Piwik_TestCase {
 			]
 		);
 
-		$this->assertSame( 'idSite=7&method=VisitsSummary.get&period=day&date=today', $url );
+		// array_merge keeps the position a string key already had, so the injected
+		// method keeps its slot but never its value
+		$this->assertSame( 'method=VisitsSummary.get&period=day&date=today&idSite=7', $url );
 	}
 
-	public function test_build_url_should_let_a_parameter_override_the_site_id() {
+	public function test_build_url_should_ignore_a_site_id_supplied_as_a_parameter() {
 		$url = $this->request->build_url_public(
 			[
 				'method'    => 'VisitsSummary.get',
@@ -289,7 +291,26 @@ class RequestTest extends WP_Piwik_TestCase {
 			]
 		);
 
-		$this->assertSame( 'idSite=12&method=VisitsSummary.get', $url );
+		$this->assertSame( 'idSite=7&method=VisitsSummary.get', $url );
+	}
+
+	public function test_build_url_should_use_the_site_id_the_request_was_registered_with() {
+		$url = $this->request->build_url_public(
+			[
+				'method'    => 'SitesManager.getJavascriptTag',
+				'parameter' => [],
+				'id_site'   => 12,
+			]
+		);
+
+		$this->assertSame( 'idSite=12&method=SitesManager.getJavascriptTag', $url );
+	}
+
+	public function test_register_should_keep_requests_for_different_sites_apart() {
+		$first  = Test_Request::register( 'VisitsSummary.get', [ 'period' => 'day' ], 7 );
+		$second = Test_Request::register( 'VisitsSummary.get', [ 'period' => 'day' ], 12 );
+
+		$this->assertNotSame( $first, $second, 'the site is part of the request identity, not an interchangeable parameter' );
 	}
 
 	public function test_get_debug_returns_false_when_no_debug_data_collected() {

--- a/tests/phpunit/RequestTest.php
+++ b/tests/phpunit/RequestTest.php
@@ -263,7 +263,33 @@ class RequestTest extends WP_Piwik_TestCase {
 			]
 		);
 
-		$this->assertSame( 'method=VisitsSummary.get&idSite=7&period=day&date=today', $url );
+		$this->assertSame( 'idSite=7&period=day&date=today&method=VisitsSummary.get', $url );
+	}
+
+	public function test_build_url_should_ignore_a_method_supplied_as_a_parameter() {
+		$url = $this->request->build_url_public(
+			[
+				'method'    => 'VisitsSummary.get',
+				'parameter' => [
+					'method' => 'SitesManager.deleteSite',
+					'period' => 'day',
+					'date'   => 'today',
+				],
+			]
+		);
+
+		$this->assertSame( 'idSite=7&method=VisitsSummary.get&period=day&date=today', $url );
+	}
+
+	public function test_build_url_should_let_a_parameter_override_the_site_id() {
+		$url = $this->request->build_url_public(
+			[
+				'method'    => 'VisitsSummary.get',
+				'parameter' => [ 'idSite' => 12 ],
+			]
+		);
+
+		$this->assertSame( 'idSite=12&method=VisitsSummary.get', $url );
 	}
 
 	public function test_get_debug_returns_false_when_no_debug_data_collected() {

--- a/tests/phpunit/RestIntegrationTest.php
+++ b/tests/phpunit/RestIntegrationTest.php
@@ -4,6 +4,7 @@ namespace WP_Piwik\Tests;
 
 use WP_Piwik\Request;
 use WP_Piwik\Request\Rest;
+use WP_Piwik\Widget\OptOut;
 
 class RestIntegrationTest extends WP_Piwik_TestCase {
 
@@ -73,7 +74,7 @@ class RestIntegrationTest extends WP_Piwik_TestCase {
 		$this->assertSame( 'API.getBulkRequest', $sent['method'] );
 		$this->assertSame( 'secret-token', $sent['token_auth'] );
 		$this->assertSame(
-			[ 'method=VisitsSummary.get&idSite=1&period=day&date=2015-01-01' ],
+			[ 'idSite=1&period=day&date=2015-01-01&method=VisitsSummary.get' ],
 			$sent['urls']
 		);
 	}
@@ -93,6 +94,57 @@ class RestIntegrationTest extends WP_Piwik_TestCase {
 		} else {
 			$this->assertStringContainsString( 'token_auth=secret-token', urldecode( $requests[0]['query'] ) );
 		}
+	}
+
+	public function test_bulk_request_should_not_carry_a_method_injected_through_a_widget() {
+		$settings = $this->create_settings(
+			[
+				'piwik_mode'         => 'http',
+				'piwik_url'          => $this->mock_url(),
+				'piwik_token'        => 'secret-token',
+				'http_connection'    => 'curl',
+				'http_method'        => 'post',
+				'cache'              => false,
+				'connection_timeout' => 15,
+			],
+			[ 'site_id' => 1 ]
+		);
+
+		$request = new Rest( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$request->reset();
+
+		// the opt-out widget used to adopt the shortcode attributes verbatim
+		new OptOut(
+			new \WP_Piwik_Test_Mock_Plugin(),
+			$settings,
+			null,
+			null,
+			null,
+			[
+				'module' => 'opt-out',
+				'method' => 'SitesManager.deleteSite',
+			],
+			true
+		);
+
+		// the opt-out widget never calls the API itself, so a second widget is
+		// what flushes the queue
+		$id = Request::register(
+			'VisitsSummary.get',
+			[
+				'period' => 'day',
+				'date'   => '2015-01-01',
+			]
+		);
+		$request->perform( $id );
+
+		$requests = $this->get_captured_requests();
+		$this->assertCount( 1, $requests );
+		$this->assertSame(
+			[ 'idSite=1&period=day&date=2015-01-01&method=VisitsSummary.get' ],
+			$requests[0]['post']['urls'],
+			'the opt-out widget must contribute no sub request, and none may carry the injected method'
+		);
 	}
 
 	/**

--- a/tests/phpunit/RestIntegrationTest.php
+++ b/tests/phpunit/RestIntegrationTest.php
@@ -74,7 +74,7 @@ class RestIntegrationTest extends WP_Piwik_TestCase {
 		$this->assertSame( 'API.getBulkRequest', $sent['method'] );
 		$this->assertSame( 'secret-token', $sent['token_auth'] );
 		$this->assertSame(
-			[ 'idSite=1&period=day&date=2015-01-01&method=VisitsSummary.get' ],
+			[ 'period=day&date=2015-01-01&idSite=1&method=VisitsSummary.get' ],
 			$sent['urls']
 		);
 	}
@@ -141,7 +141,7 @@ class RestIntegrationTest extends WP_Piwik_TestCase {
 		$requests = $this->get_captured_requests();
 		$this->assertCount( 1, $requests );
 		$this->assertSame(
-			[ 'idSite=1&period=day&date=2015-01-01&method=VisitsSummary.get' ],
+			[ 'period=day&date=2015-01-01&idSite=1&method=VisitsSummary.get' ],
 			$requests[0]['post']['urls'],
 			'the opt-out widget must contribute no sub request, and none may carry the injected method'
 		);

--- a/tests/phpunit/RestTest.php
+++ b/tests/phpunit/RestTest.php
@@ -82,8 +82,8 @@ class RestTest extends WP_Piwik_TestCase {
 
 		$this->assertSame(
 			[
-				'idSite=7&period=day&date=2015-01-01&method=VisitsSummary.get',
-				'idSite=7&period=day&date=2015-01-02&method=VisitsSummary.get',
+				'period=day&date=2015-01-01&idSite=7&method=VisitsSummary.get',
+				'period=day&date=2015-01-02&idSite=7&method=VisitsSummary.get',
 			],
 			$params['urls']
 		);
@@ -126,7 +126,7 @@ class RestTest extends WP_Piwik_TestCase {
 				'module'     => 'API',
 				'method'     => 'API.getBulkRequest',
 				'format'     => 'json',
-				'urls'       => [ 'idSite=7&period=day&date=2015-01-01&method=VisitsSummary.get' ],
+				'urls'       => [ 'period=day&date=2015-01-01&idSite=7&method=VisitsSummary.get' ],
 				'token_auth' => 'secret-token',
 			],
 			$decoded
@@ -148,9 +148,9 @@ class RestTest extends WP_Piwik_TestCase {
 
 		$this->assertSame(
 			[
-				'idSite' => '7',
 				'period' => 'day',
 				'date'   => '2015-01-01',
+				'idSite' => '7',
 				'method' => 'VisitsSummary.get',
 			],
 			$sub_request
@@ -163,7 +163,7 @@ class RestTest extends WP_Piwik_TestCase {
 		list( $params ) = $this->request->build_bulk_params_public();
 		$body           = $this->request->build_param_string_public( $params );
 
-		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&urls%5B0%5D=idSite%3D7%26period%3Dday%26date%3D2015-01-01%26method%3DVisitsSummary.get&token_auth=secret-token', $body );
+		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&urls%5B0%5D=period%3Dday%26date%3D2015-01-01%26idSite%3D7%26method%3DVisitsSummary.get&token_auth=secret-token', $body );
 	}
 
 	public function test_request_body_can_mask_the_auth_token_for_debug_output() {
@@ -266,7 +266,7 @@ class RestTest extends WP_Piwik_TestCase {
 		list( $params, $map ) = $this->request->build_bulk_params_public();
 
 		$this->assertSame(
-			[ 'idSite=7&period=day&date=2015-01-02&method=VisitsSummary.get' ],
+			[ 'period=day&date=2015-01-02&idSite=7&method=VisitsSummary.get' ],
 			$params['urls']
 		);
 		$this->assertSame( [ 'method=VisitsSummary.get&period=day&date=2015-01-02' ], array_values( $map ) );

--- a/tests/phpunit/RestTest.php
+++ b/tests/phpunit/RestTest.php
@@ -82,8 +82,8 @@ class RestTest extends WP_Piwik_TestCase {
 
 		$this->assertSame(
 			[
-				'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-01',
-				'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-02',
+				'idSite=7&period=day&date=2015-01-01&method=VisitsSummary.get',
+				'idSite=7&period=day&date=2015-01-02&method=VisitsSummary.get',
 			],
 			$params['urls']
 		);
@@ -126,7 +126,7 @@ class RestTest extends WP_Piwik_TestCase {
 				'module'     => 'API',
 				'method'     => 'API.getBulkRequest',
 				'format'     => 'json',
-				'urls'       => [ 'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-01' ],
+				'urls'       => [ 'idSite=7&period=day&date=2015-01-01&method=VisitsSummary.get' ],
 				'token_auth' => 'secret-token',
 			],
 			$decoded
@@ -148,10 +148,10 @@ class RestTest extends WP_Piwik_TestCase {
 
 		$this->assertSame(
 			[
-				'method' => 'VisitsSummary.get',
 				'idSite' => '7',
 				'period' => 'day',
 				'date'   => '2015-01-01',
+				'method' => 'VisitsSummary.get',
 			],
 			$sub_request
 		);
@@ -163,7 +163,7 @@ class RestTest extends WP_Piwik_TestCase {
 		list( $params ) = $this->request->build_bulk_params_public();
 		$body           = $this->request->build_param_string_public( $params );
 
-		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&urls%5B0%5D=method%3DVisitsSummary.get%26idSite%3D7%26period%3Dday%26date%3D2015-01-01&token_auth=secret-token', $body );
+		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&urls%5B0%5D=idSite%3D7%26period%3Dday%26date%3D2015-01-01%26method%3DVisitsSummary.get&token_auth=secret-token', $body );
 	}
 
 	public function test_request_body_can_mask_the_auth_token_for_debug_output() {
@@ -266,7 +266,7 @@ class RestTest extends WP_Piwik_TestCase {
 		list( $params, $map ) = $this->request->build_bulk_params_public();
 
 		$this->assertSame(
-			[ 'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-02' ],
+			[ 'idSite=7&period=day&date=2015-01-02&method=VisitsSummary.get' ],
 			$params['urls']
 		);
 		$this->assertSame( [ 'method=VisitsSummary.get&period=day&date=2015-01-02' ], array_values( $map ) );

--- a/tests/phpunit/SettingsTest.php
+++ b/tests/phpunit/SettingsTest.php
@@ -185,6 +185,37 @@ class SettingsTest extends WP_Piwik_TestCase {
 		$this->assertNotEmpty( $settings->get_global_option( 'last_settings_update' ) );
 	}
 
+	public function test_get_global_option_defaults_the_shortcode_author_check_to_enabled() {
+		$settings = $this->create_settings();
+
+		$this->assertTrue( $settings->get_global_option( 'shortcode_author_check' ) );
+	}
+
+	public function test_apply_changes_persists_a_disabled_shortcode_author_check() {
+		$settings = $this->create_settings();
+
+		$settings->apply_changes(
+			[
+				'shortcodes'             => 1,
+				'shortcode_author_check' => 0,
+			]
+		);
+
+		$this->assertFalse( (bool) $settings->get_global_option( 'shortcode_author_check' ) );
+		$this->assertSame( '0', (string) get_option( 'wp-piwik_global-shortcode_author_check' ) );
+	}
+
+	public function test_apply_changes_re_enables_a_shortcode_author_check_the_form_did_not_submit() {
+		$settings = $this->create_settings( [ 'shortcode_author_check' => 0 ] );
+
+		// apply_changes() writes the default for every setting missing from the
+		// submitted configuration, so a settings form that stops rendering this row
+		// silently turns the check back on
+		$settings->apply_changes( [ 'shortcodes' => 1 ] );
+
+		$this->assertTrue( (bool) $settings->get_global_option( 'shortcode_author_check' ) );
+	}
+
 	public function test_apply_changes_requests_site_id_when_auto_config_is_enabled() {
 		$plugin                = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->piwik_site_id = 42;

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -1,0 +1,561 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request;
+use WP_Piwik\Shortcode;
+
+/**
+ * Records the requests a shortcode queues without sending any of them.
+ */
+class Shortcode_Test_Request extends Request {
+
+	protected function request( $id ) {
+	}
+
+	public static function get_registered() {
+		return self::$requests;
+	}
+}
+
+class ShortcodeTest extends WP_Piwik_TestCase {
+
+	private $settings_backup = [];
+
+	private $role_caps_to_revoke = [];
+
+	public function set_up() {
+		parent::set_up();
+
+		$settings              = \WP_Piwik::get_settings();
+		$this->settings_backup = [
+			'piwik_mode'             => $settings->get_global_option( 'piwik_mode' ),
+			'piwik_url'              => $settings->get_global_option( 'piwik_url' ),
+			'default_date'           => $settings->get_global_option( 'default_date' ),
+			'shortcode_author_check' => $settings->get_global_option( 'shortcode_author_check' ),
+			'site_id'                => $settings->get_option( 'site_id' ),
+		];
+
+		$settings->set_global_option( 'piwik_mode', 'disabled' );
+		$settings->set_global_option( 'piwik_url', 'https://matomo.example.org/' );
+		$settings->set_global_option( 'default_date', 'yesterday' );
+		$settings->set_global_option( 'shortcode_author_check', true );
+		$settings->set_option( 'site_id', 7 );
+
+		// constructing the request registers API.getPiwikVersion, reset() clears it
+		$request = new Shortcode_Test_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$request->reset();
+
+		wp_set_current_user( 0 );
+		$this->set_current_post( null );
+	}
+
+	public function tear_down() {
+		$settings = \WP_Piwik::get_settings();
+		foreach ( [ 'piwik_mode', 'piwik_url', 'default_date', 'shortcode_author_check' ] as $key ) {
+			$settings->set_global_option( $key, $this->settings_backup[ $key ] );
+		}
+		$settings->set_option( 'site_id', $this->settings_backup['site_id'] );
+
+		// role capabilities live in an option that the test transaction rolls back,
+		// but also in the wp_roles global, which survives the rollback.
+		foreach ( $this->role_caps_to_revoke as $role_name ) {
+			$role = get_role( $role_name );
+			if ( $role ) {
+				$role->remove_cap( 'wp-piwik_read_stats' );
+			}
+		}
+		$this->role_caps_to_revoke = [];
+
+		$this->set_current_post( null );
+
+		parent::tear_down();
+	}
+
+	public function test_render_should_default_to_the_overview_module() {
+		$this->render( '' );
+
+		$this->assertSame(
+			[ 'VisitsSummary.get' ],
+			$this->get_registered_methods(),
+			'readme.txt documents [wp-piwik] as equal to [wp-piwik module="overview"]'
+		);
+	}
+
+	public function test_render_should_return_null_for_an_unknown_module() {
+		$this->assertNull( $this->render( 'module=nope' ) );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_pass_supported_attributes_to_the_widget() {
+		$output = $this->render( 'module=opt-out language=de width=50% height=90px idsite=9' );
+
+		$this->assertStringContainsString( 'width="50%"', $output );
+		$this->assertStringContainsString( 'height="90px"', $output );
+		$this->assertStringContainsString( 'idsite=9', $output );
+		$this->assertStringContainsString( 'language=de', $output );
+	}
+
+	public function test_render_should_drop_unsupported_attributes() {
+		$this->render( 'module=overview method=SitesManager.deleteSite urls=http://attacker.example note=x' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame(
+			[],
+			array_intersect( [ 'method', 'urls', 'note' ], array_keys( $parameters ) )
+		);
+	}
+
+	public function test_render_should_ignore_an_injected_api_method() {
+		$output = $this->render( 'module=opt-out method=SitesManager.deleteSite' );
+
+		$this->assertStringContainsString( '<iframe', $output, 'precondition: the opt-out widget rendered' );
+		$this->assertSame(
+			[],
+			Shortcode_Test_Request::get_registered(),
+			'the opt-out widget performs no API call, so it must queue no request at all'
+		);
+	}
+
+	/**
+	 * @dataProvider get_unusable_attributes
+	 */
+	public function test_render_should_drop_an_attribute_value_matomo_would_not_accept( $attributes, $key, $expected ) {
+		$this->render( 'module=overview ' . $attributes );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( $expected, $parameters[ $key ] );
+	}
+
+	public function get_unusable_attributes() {
+		return [
+			'unknown period'         => [ 'period=decade date=today', 'period', 'day' ],
+			'period with a segment'  => [ 'period=day;segment=x date=today', 'period', 'day' ],
+			'malformed date'         => [ 'period=day date=lastyear', 'date', 'yesterday' ],
+			'date with a parameter'  => [ 'period=day date=today&flat=1', 'date', 'yesterday' ],
+			'implausible last range' => [ 'period=day date=last99999', 'date', 'yesterday' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_documented_dates
+	 */
+	public function test_render_should_keep_a_documented_date( $date ) {
+		$this->render( 'module=overview period=range date=' . $date );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( $date, $parameters['date'] );
+	}
+
+	public function get_documented_dates() {
+		return [
+			[ 'today' ],
+			[ 'yesterday' ],
+			[ 'last30' ],
+			[ 'previous7' ],
+			[ '2024-01-31' ],
+			[ '2024-01-01,2024-01-31' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_matomo_periods
+	 */
+	public function test_render_should_keep_a_period_matomo_supports( $period ) {
+		$this->render( 'module=overview period=' . $period . ' date=today' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( $period, $parameters['period'] );
+	}
+
+	public function get_matomo_periods() {
+		return [
+			[ 'day' ],
+			[ 'week' ],
+			[ 'month' ],
+			[ 'year' ],
+			[ 'range' ],
+		];
+	}
+
+	public function test_render_should_keep_honouring_the_default_date_setting() {
+		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
+
+		$this->render( 'module=overview' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( 'month', $parameters['period'] );
+		$this->assertSame( 'today', $parameters['date'] );
+	}
+
+	public function test_render_should_let_an_explicit_date_win_over_the_default_date_setting() {
+		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
+
+		$this->render( 'module=overview period=day date=last30' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( 'day', $parameters['period'] );
+		$this->assertSame( 'last30', $parameters['date'] );
+	}
+
+	public function test_render_should_drop_a_malformed_language() {
+		$output = $this->render( 'module=opt-out language=de&idsite=9' );
+
+		$this->assertStringContainsString( 'language=en', $output, 'the opt-out widget falls back to its own default' );
+	}
+
+	public function test_render_should_keep_a_plain_language_code() {
+		$output = $this->render( 'module=opt-out language=de' );
+
+		$this->assertStringContainsString( 'language=de', $output );
+	}
+
+	public function test_render_should_render_the_overview_when_the_post_author_can_read_stats() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertStringContainsString( '<table', $output );
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_not_render_the_overview_when_the_post_author_cannot_read_stats() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered(), 'no request may be queued for a shortcode that is not allowed to run' );
+	}
+
+	public function test_render_should_render_the_post_module_when_the_post_author_can_read_stats() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$this->render( 'module=post key=nb_visits' );
+
+		$this->assertSame( [ 'Actions.getPageUrl' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_not_render_the_post_module_when_the_post_author_cannot_read_stats() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$output = $this->render( 'module=post key=nb_visits' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_render_the_opt_out_module_when_the_post_author_cannot_read_stats() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$output = $this->render( 'module=opt-out' );
+
+		$this->assertStringContainsString( '<iframe', $output, 'the opt-out iframe requests no data and has to stay reachable' );
+	}
+
+	public function test_render_should_render_the_overview_when_the_author_check_is_disabled() {
+		\WP_Piwik::get_settings()->set_global_option( 'shortcode_author_check', false );
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$this->render( 'module=overview' );
+
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_render_the_overview_when_no_post_can_be_resolved() {
+		$this->render( 'module=overview' );
+
+		$this->assertSame(
+			[ 'VisitsSummary.get' ],
+			$this->get_registered_methods(),
+			'a shortcode outside a post comes from a theme or a widget, which needs wider capabilities to edit'
+		);
+	}
+
+	public function test_render_should_not_render_the_post_module_when_no_post_can_be_resolved() {
+		$output = $this->render( 'module=post key=nb_visits' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_render_the_overview_in_the_main_loop_when_the_post_author_can_read_stats() {
+		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->set_current_post( null );
+
+		$this->go_to( get_permalink( $post_id ) );
+		the_post();
+
+		$this->render( 'module=overview' );
+
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_not_render_the_overview_in_the_main_loop_when_the_post_author_cannot_read_stats() {
+		$post_id = $this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->set_current_post( null );
+
+		$this->go_to( get_permalink( $post_id ) );
+		the_post();
+
+		$this->assertSame( '', $this->render( 'module=overview' ) );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_follow_the_read_stats_capability_of_the_author_role() {
+		$author_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		$this->given_a_post_authored_by( $author_id );
+
+		$this->assertSame( '', $this->render( 'module=overview' ), 'precondition: the author role may not read stats' );
+
+		$this->grant_read_stats_to_role( 'author' );
+
+		$this->render( 'module=overview' );
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_use_the_current_post_url_when_no_url_is_given() {
+		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$this->render( 'module=post' );
+
+		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
+		$this->assertSame( get_permalink( $post_id ), $parameters['pageUrl'] );
+	}
+
+	public function test_render_should_accept_a_url_the_author_may_read() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$other_url = get_permalink( $other_id );
+
+		$this->render( 'module=post url=' . $other_url );
+
+		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
+		$this->assertSame( $other_url, $parameters['pageUrl'] );
+	}
+
+	public function test_render_should_accept_a_url_of_this_site_written_with_the_other_scheme() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$other_url = set_url_scheme( get_permalink( $other_id ), 'https' === wp_parse_url( home_url(), PHP_URL_SCHEME ) ? 'http' : 'https' );
+
+		$this->render( 'module=post url=' . $other_url );
+
+		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
+		$this->assertSame( $other_url, $parameters['pageUrl'], 'a shortcode written before the site moved to HTTPS keeps working' );
+	}
+
+	public function test_render_should_reject_an_off_site_url() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render( 'module=post url=https://attacker.example/some-page/' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_reject_an_admin_url() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render( 'module=post url=' . admin_url( 'index.php' ) );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_reject_a_url_the_author_may_not_read() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$private_id = self::factory()->post->create(
+			[
+				'post_status' => 'private',
+				'post_author' => self::factory()->user->create( [ 'role' => 'administrator' ] ),
+			]
+		);
+
+		$output = $this->render( 'module=post url=' . get_permalink( $private_id ) );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_reject_a_url_of_a_host_that_only_looks_like_this_site() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render( 'module=post url=' . home_url() . '.attacker.example/?p=1' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_let_the_authorized_filter_block_an_allowed_shortcode() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		add_filter( 'wp-piwik_shortcode_authorized', '__return_false' );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_let_the_authorized_filter_allow_a_blocked_shortcode() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+		add_filter( 'wp-piwik_shortcode_authorized', '__return_true' );
+
+		$this->render( 'module=overview' );
+
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_let_the_authorized_filter_block_with_a_wp_error() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->deny_through_the_authorized_filter( 'the editorial policy forbids stats here' );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_show_an_administrator_the_message_of_a_wp_error_from_the_authorized_filter() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->deny_through_the_authorized_filter( 'the editorial policy forbids stats here' );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertStringContainsString( 'the editorial policy forbids stats here', $output );
+		$this->assertStringNotContainsString( 'Array', $output, 'the WP_Error message is a string, not the array get_error_messages() returns' );
+	}
+
+	public function test_render_should_report_only_the_first_message_of_a_multi_message_wp_error() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		add_filter(
+			'wp-piwik_shortcode_authorized',
+			function () {
+				$error = new \WP_Error( 'wp_piwik_test_denial', 'first reason' );
+				$error->add( 'wp_piwik_test_denial', 'second reason' );
+				return $error;
+			}
+		);
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertStringContainsString( 'first reason', $output );
+		$this->assertStringNotContainsString( 'Array', $output );
+	}
+
+	public function test_render_should_pass_the_attributes_and_the_post_to_the_authorized_filter() {
+		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$seen    = [];
+		add_filter(
+			'wp-piwik_shortcode_authorized',
+			function ( $authorized, $attributes, $post ) use ( &$seen ) {
+				$seen = [
+					'module'  => $attributes['module'],
+					'post_id' => $post instanceof \WP_Post ? $post->ID : null,
+				];
+				return $authorized;
+			},
+			10,
+			3
+		);
+
+		$this->render( 'module=overview' );
+
+		$this->assertSame(
+			[
+				'module'  => 'overview',
+				'post_id' => $post_id,
+			],
+			$seen
+		);
+	}
+
+	public function test_render_should_return_nothing_to_a_visitor_when_it_blocks_a_shortcode() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertSame( '', $output, 'not even an HTML comment, which would tell a visitor which check failed' );
+	}
+
+	public function test_render_should_explain_to_an_administrator_why_it_blocked_a_shortcode() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$output = $this->render( 'module=overview' );
+
+		$this->assertStringContainsString( 'wp-piwik-shortcode-denied', $output );
+		$this->assertStringContainsString( 'not allowed to see the statistics', $output );
+	}
+
+	private function render( $attributes ) {
+		$shortcode = new Shortcode( $GLOBALS['wp-piwik'], \WP_Piwik::get_settings() );
+		return $shortcode->render( shortcode_parse_atts( $attributes ) );
+	}
+
+	/**
+	 * Create a user who may or may not see the statistics
+	 *
+	 * @param bool $can_read_stats whether the user may see the statistics
+	 * @return int user ID
+	 */
+	private function create_author( $can_read_stats ) {
+		$user_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		if ( $can_read_stats ) {
+			$user = new \WP_User( $user_id );
+			$user->add_cap( 'wp-piwik_read_stats' );
+		}
+		return $user_id;
+	}
+
+	/**
+	 * @param string $message reason the filter reports back
+	 */
+	private function deny_through_the_authorized_filter( $message ) {
+		add_filter(
+			'wp-piwik_shortcode_authorized',
+			function () use ( $message ) {
+				return new \WP_Error( 'wp_piwik_test_denial', $message );
+			}
+		);
+	}
+
+	private function grant_read_stats_to_role( $role_name ) {
+		get_role( $role_name )->add_cap( 'wp-piwik_read_stats' );
+		$this->role_caps_to_revoke[] = $role_name;
+	}
+
+	private function given_a_post_authored_by( $author_id ) {
+		$post_id = self::factory()->post->create(
+			[
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			]
+		);
+		$this->set_current_post( get_post( $post_id ) );
+		return $post_id;
+	}
+
+	/**
+	 * @param \WP_Post|null $post post the shortcode is rendered in
+	 */
+	private function set_current_post( $post ) {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['post'] = $post;
+	}
+
+	private function get_registered_methods() {
+		return array_values( wp_list_pluck( Shortcode_Test_Request::get_registered(), 'method' ) );
+	}
+
+	private function get_registered_parameters( $method ) {
+		foreach ( Shortcode_Test_Request::get_registered() as $config ) {
+			if ( $method === $config['method'] ) {
+				return $config['parameter'];
+			}
+		}
+		$this->fail( 'No request was registered for ' . $method );
+	}
+}

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -46,6 +46,9 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$request = new Shortcode_Test_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
 		$request->reset();
 
+		add_shortcode( Shortcode::TAG, array( $GLOBALS['wp-piwik'], 'shortcode' ) );
+		add_filter( 'render_block', array( $GLOBALS['wp-piwik'], 'render_shortcodes_in_reusable_block' ), 10, 2 );
+
 		wp_set_current_user( 0 );
 		$this->set_current_post( null );
 	}
@@ -66,6 +69,9 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			}
 		}
 		$this->role_caps_to_revoke = [];
+
+		remove_shortcode( Shortcode::TAG );
+		remove_shortcode( 'wp_piwik_test_other' );
 
 		$this->set_current_post( null );
 
@@ -387,6 +393,121 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
 	}
 
+	public function test_render_should_reject_a_url_on_another_port() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$other_id              = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$other_on_another_port = str_replace(
+			wp_parse_url( home_url(), PHP_URL_HOST ),
+			wp_parse_url( home_url(), PHP_URL_HOST ) . ':8080',
+			get_permalink( $other_id )
+		);
+
+		$output = $this->render( 'module=post url=' . $other_on_another_port );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_accept_a_url_stating_the_default_port_of_a_scheme() {
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$other_url = str_replace(
+			wp_parse_url( home_url(), PHP_URL_HOST ),
+			wp_parse_url( home_url(), PHP_URL_HOST ) . ':80',
+			get_permalink( $other_id )
+		);
+
+		$this->render( 'module=post url=' . $other_url );
+
+		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
+		$this->assertSame( $other_url, $parameters['pageUrl'] );
+	}
+
+	public function test_render_should_authorize_a_reusable_block_against_its_own_author() {
+		$block_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_author'  => $this->create_author( false ),
+				'post_content' => '[wp-piwik module="overview"]',
+			]
+		);
+		// the embedding post belongs to somebody who may see the statistics
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render_reusable_block( $block_id );
+
+		$this->assertSame( '', $output, 'the block author may not see the statistics, so the block borrowing the embedding author is a bypass' );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_render_a_reusable_block_whose_author_may_read_stats() {
+		$block_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_author'  => $this->create_author( true ),
+				'post_content' => '[wp-piwik module="overview"]',
+			]
+		);
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+
+		$this->render_reusable_block( $block_id );
+
+		$this->assertSame( [ 'VisitsSummary.get' ], $this->get_registered_methods() );
+	}
+
+	public function test_render_should_leave_the_global_post_alone_after_rendering_a_reusable_block() {
+		$block_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_author'  => $this->create_author( true ),
+				'post_content' => '[wp-piwik module="overview"]',
+			]
+		);
+		$post_id  = $this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$this->render_reusable_block( $block_id );
+
+		$this->assertSame( $post_id, $GLOBALS['post']->ID );
+		$this->assertArrayHasKey( 'wp-piwik', $GLOBALS['shortcode_tags'], 'the narrowed tag list has to be restored' );
+	}
+
+	public function test_render_should_leave_other_shortcodes_in_a_reusable_block_to_the_usual_pass() {
+		$block_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_author'  => $this->create_author( true ),
+				'post_content' => '[wp-piwik module="opt-out"][wp_piwik_test_other]',
+			]
+		);
+		add_shortcode( 'wp_piwik_test_other', '__return_empty_string' );
+		$this->given_a_post_authored_by( $this->create_author( true ) );
+
+		$output = $this->render_reusable_block( $block_id );
+
+		$this->assertStringContainsString( '<iframe', $output );
+		$this->assertStringContainsString( '[wp_piwik_test_other]', $output, 'only this plugin\'s tag is expanded early' );
+	}
+
+	public function test_render_should_ignore_blocks_that_are_not_reusable() {
+		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$shortcode = new Shortcode( $GLOBALS['wp-piwik'], \WP_Piwik::get_settings() );
+
+		$output = $shortcode->render_reusable_block(
+			'[wp-piwik module="overview"]',
+			[
+				'blockName' => 'core/paragraph',
+				'attrs'     => [],
+			]
+		);
+
+		$this->assertSame( '[wp-piwik module="overview"]', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
 	public function test_render_should_let_the_authorized_filter_block_an_allowed_shortcode() {
 		$this->given_a_post_authored_by( $this->create_author( true ) );
 		add_filter( 'wp-piwik_shortcode_authorized', '__return_false' );
@@ -493,6 +614,19 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	private function render( $attributes ) {
 		$shortcode = new Shortcode( $GLOBALS['wp-piwik'], \WP_Piwik::get_settings() );
 		return $shortcode->render( shortcode_parse_atts( $attributes ) );
+	}
+
+	private function render_reusable_block( $block_id ) {
+		$block = get_post( $block_id );
+		return apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			'render_block',
+			$block->post_content,
+			[
+				'blockName' => 'core/block',
+				'attrs'     => [ 'ref' => $block_id ],
+			]
+		);
 	}
 
 	/**

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -433,15 +433,17 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_a_url_on_another_port() {
+		$this->set_permalink_structure( '' );
 		$this->set_home_url_without_a_port();
+
 		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id              = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+
 		$other_on_another_port = str_replace(
 			wp_parse_url( home_url(), PHP_URL_HOST ),
 			wp_parse_url( home_url(), PHP_URL_HOST ) . ':8080',
 			get_permalink( $other_id )
 		);
-
 		$output = $this->render( 'module=post url=' . $other_on_another_port );
 
 		$this->assertSame( '', $output );
@@ -449,6 +451,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_accept_a_url_stating_the_default_port_of_a_scheme() {
+		$this->set_permalink_structure( '' );
 		$this->set_home_url_without_a_port();
 		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
@@ -457,6 +460,15 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			wp_parse_url( home_url(), PHP_URL_HOST ) . ':80',
 			get_permalink( $other_id )
 		);
+
+		print "$other_id\n";
+		print get_permalink($other_id)."\n";
+		print $other_url."\n";
+		print home_url()."\n";
+		print home_url('/')."\n";
+		print wp_parse_url($other_url, PHP_URL_HOST)."\n";
+		print wp_parse_url(home_url(), PHP_URL_HOST)."\n";
+		@ob_flush();
 
 		$this->render( 'module=post url=' . $other_url );
 
@@ -759,6 +771,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 				'post_status' => 'publish',
 			]
 		);
+		print "permalink: ". get_permalink($post_id)."\n";@ob_flush();
 		$this->set_current_post( get_post( $post_id ) );
 		return $post_id;
 	}
@@ -786,13 +799,11 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 	private function set_home_url_without_a_port() {
 		$home_url = 'http://example.org';
-		foreach ( [ 'option_name', 'option_siteurl' ] as $option ) {
-			add_filter(
-				$option,
-				function () use ( $home_url ) {
-					return $home_url;
-				}
-			);
-		}
+		add_filter(
+			'home_url',
+			function () use ( $home_url ) {
+				return $home_url;
+			}
+		);
 	}
 }

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -433,6 +433,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_a_url_on_another_port() {
+		$this->set_home_url_without_a_port();
 		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id              = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_on_another_port = str_replace(
@@ -448,6 +449,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_accept_a_url_stating_the_default_port_of_a_scheme() {
+		$this->set_home_url_without_a_port();
 		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_url = str_replace(
@@ -780,5 +782,17 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			}
 		}
 		$this->fail( 'No request was registered for ' . $method );
+	}
+
+	private function set_home_url_without_a_port() {
+		$home_url = 'http://example.org';
+		foreach ( [ 'option_name', 'option_siteurl' ] as $option ) {
+			add_filter(
+				$option,
+				function () use ( $home_url ) {
+					return $home_url;
+				}
+			);
+		}
 	}
 }

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -438,13 +438,12 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id              = self::factory()->post->create( [ 'post_status' => 'publish' ] );
-
 		$other_on_another_port = str_replace(
 			wp_parse_url( home_url(), PHP_URL_HOST ),
 			wp_parse_url( home_url(), PHP_URL_HOST ) . ':8080',
 			get_permalink( $other_id )
 		);
-		$output = $this->render( 'module=post url=' . $other_on_another_port );
+		$output                = $this->render( 'module=post url=' . $other_on_another_port );
 
 		$this->assertSame( '', $output );
 		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
@@ -460,15 +459,6 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			wp_parse_url( home_url(), PHP_URL_HOST ) . ':80',
 			get_permalink( $other_id )
 		);
-
-		print "$other_id\n";
-		print get_permalink($other_id)."\n";
-		print $other_url."\n";
-		print home_url()."\n";
-		print home_url('/')."\n";
-		print wp_parse_url($other_url, PHP_URL_HOST)."\n";
-		print wp_parse_url(home_url(), PHP_URL_HOST)."\n";
-		@ob_flush();
 
 		$this->render( 'module=post url=' . $other_url );
 
@@ -771,7 +761,6 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 				'post_status' => 'publish',
 			]
 		);
-		print "permalink: ". get_permalink($post_id)."\n";@ob_flush();
 		$this->set_current_post( get_post( $post_id ) );
 		return $post_id;
 	}
@@ -801,9 +790,11 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$home_url = 'http://example.org';
 		add_filter(
 			'home_url',
-			function () use ( $home_url ) {
-				return $home_url;
-			}
+			function ( $url, $path ) use ( $home_url ) {
+				return $home_url . ( $path ? '/' . ltrim( $path, '/' ) : '' );
+			},
+			10,
+			2
 		);
 	}
 }

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -24,6 +24,8 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 	private $role_caps_to_revoke = [];
 
+	private $permalink_structure_changed = false;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -69,6 +71,13 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			}
 		}
 		$this->role_caps_to_revoke = [];
+
+		// the permalink structure lives in an option the test transaction rolls back,
+		// but also in the wp_rewrite global, which survives the rollback.
+		if ( $this->permalink_structure_changed ) {
+			$this->set_permalink_structure();
+			$this->permalink_structure_changed = false;
+		}
 
 		remove_shortcode( Shortcode::TAG );
 		remove_shortcode( 'wp_piwik_test_other' );
@@ -217,7 +226,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_render_the_overview_when_the_post_author_can_read_stats() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render( 'module=overview' );
 
@@ -226,7 +235,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_not_render_the_overview_when_the_post_author_cannot_read_stats() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$output = $this->render( 'module=overview' );
 
@@ -235,7 +244,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_render_the_post_module_when_the_post_author_can_read_stats() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$this->render( 'module=post key=nb_visits' );
 
@@ -243,7 +252,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_not_render_the_post_module_when_the_post_author_cannot_read_stats() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$output = $this->render( 'module=post key=nb_visits' );
 
@@ -252,7 +261,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_render_the_opt_out_module_when_the_post_author_cannot_read_stats() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$output = $this->render( 'module=opt-out' );
 
@@ -261,7 +270,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 	public function test_render_should_render_the_overview_when_the_author_check_is_disabled() {
 		\WP_Piwik::get_settings()->set_global_option( 'shortcode_author_check', false );
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$this->render( 'module=overview' );
 
@@ -286,7 +295,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_render_the_overview_in_the_main_loop_when_the_post_author_can_read_stats() {
-		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$post_id = $this->create_post_and_set_as_current( $this->create_author( true ) );
 		$this->set_current_post( null );
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -298,7 +307,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_not_render_the_overview_in_the_main_loop_when_the_post_author_cannot_read_stats() {
-		$post_id = $this->given_a_post_authored_by( $this->create_author( false ) );
+		$post_id = $this->create_post_and_set_as_current( $this->create_author( false ) );
 		$this->set_current_post( null );
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -310,7 +319,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 	public function test_render_should_follow_the_read_stats_capability_of_the_author_role() {
 		$author_id = self::factory()->user->create( [ 'role' => 'author' ] );
-		$this->given_a_post_authored_by( $author_id );
+		$this->create_post_and_set_as_current( $author_id );
 
 		$this->assertSame( '', $this->render( 'module=overview' ), 'precondition: the author role may not read stats' );
 
@@ -321,7 +330,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_use_the_current_post_url_when_no_url_is_given() {
-		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$post_id = $this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$this->render( 'module=post' );
 
@@ -330,7 +339,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_accept_a_url_the_author_may_read() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_url = get_permalink( $other_id );
 
@@ -341,7 +350,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_accept_a_url_of_this_site_written_with_the_other_scheme() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_url = set_url_scheme( get_permalink( $other_id ), 'https' === wp_parse_url( home_url(), PHP_URL_SCHEME ) ? 'http' : 'https' );
 
@@ -352,7 +361,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_an_off_site_url() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render( 'module=post url=https://attacker.example/some-page/' );
 
@@ -361,7 +370,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_an_admin_url() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render( 'module=post url=' . admin_url( 'index.php' ) );
 
@@ -370,7 +379,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_a_url_the_author_may_not_read() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$private_id = self::factory()->post->create(
 			[
 				'post_status' => 'private',
@@ -384,8 +393,38 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
 	}
 
+	public function test_render_should_reject_an_admin_url_naming_a_readable_post_in_its_fragment() {
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
+		$readable_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$output = $this->render( 'module=post url=' . admin_url( 'index.php' ) . '#?p=' . $readable_id );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
+	public function test_render_should_reject_a_url_the_author_may_not_read_naming_a_readable_post_in_its_fragment() {
+		$this->set_pretty_permalink_structure();
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
+		$readable_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		self::factory()->post->create(
+			[
+				'post_status' => 'private',
+				'post_name'   => 'embargoed-story',
+				'post_author' => self::factory()->user->create( [ 'role' => 'administrator' ] ),
+			]
+		);
+
+		$private_url = home_url( '/embargoed-story/' );
+
+		$output = $this->render( 'module=post url=' . $private_url . '#?p=' . $readable_id );
+
+		$this->assertSame( '', $output );
+		$this->assertSame( [], Shortcode_Test_Request::get_registered() );
+	}
+
 	public function test_render_should_reject_a_url_of_a_host_that_only_looks_like_this_site() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render( 'module=post url=' . home_url() . '.attacker.example/?p=1' );
 
@@ -394,7 +433,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_reject_a_url_on_another_port() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id              = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_on_another_port = str_replace(
 			wp_parse_url( home_url(), PHP_URL_HOST ),
@@ -409,7 +448,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_accept_a_url_stating_the_default_port_of_a_scheme() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$other_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$other_url = str_replace(
 			wp_parse_url( home_url(), PHP_URL_HOST ),
@@ -433,7 +472,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			]
 		);
 		// the embedding post belongs to somebody who may see the statistics
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render_reusable_block( $block_id );
 
@@ -450,7 +489,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 				'post_content' => '[wp-piwik module="overview"]',
 			]
 		);
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$this->render_reusable_block( $block_id );
 
@@ -466,7 +505,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 				'post_content' => '[wp-piwik module="overview"]',
 			]
 		);
-		$post_id  = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$post_id  = $this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$this->render_reusable_block( $block_id );
 
@@ -484,7 +523,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 			]
 		);
 		add_shortcode( 'wp_piwik_test_other', '__return_empty_string' );
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 
 		$output = $this->render_reusable_block( $block_id );
 
@@ -492,8 +531,44 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$this->assertStringContainsString( '[wp_piwik_test_other]', $output, 'only this plugin\'s tag is expanded early' );
 	}
 
+	/**
+	 * @dataProvider get_block_pass_counts
+	 */
+	public function test_render_should_not_leave_an_escaped_shortcode_in_a_reusable_block_to_the_usual_pass( $block_passes ) {
+		$escaped  = str_repeat( '[', $block_passes + 1 ) . 'wp-piwik module="overview"' . str_repeat( ']', $block_passes + 1 );
+		$block_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_author'  => $this->create_author( false ),
+				'post_content' => $escaped,
+			]
+		);
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
+
+		$block_content = $escaped;
+		for ( $pass = 0; $pass < $block_passes; $pass++ ) {
+			$block_content = $this->render_reusable_block( $block_id, $block_content );
+		}
+		$output = do_shortcode( $block_content );
+
+		$this->assertSame(
+			[],
+			Shortcode_Test_Request::get_registered(),
+			'the block author may not see the statistics, so no pass may expand the shortcode'
+		);
+		$this->assertStringNotContainsString( '<table', $output );
+	}
+
+	public function get_block_pass_counts() {
+		return [
+			'one render_block pass'   => [ 1 ],
+			'two render_block passes' => [ 2 ],
+		];
+	}
+
 	public function test_render_should_ignore_blocks_that_are_not_reusable() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 		$shortcode = new Shortcode( $GLOBALS['wp-piwik'], \WP_Piwik::get_settings() );
 
 		$output = $shortcode->render_reusable_block(
@@ -509,7 +584,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_let_the_authorized_filter_block_an_allowed_shortcode() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		add_filter( 'wp-piwik_shortcode_authorized', '__return_false' );
 
 		$output = $this->render( 'module=overview' );
@@ -519,7 +594,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_let_the_authorized_filter_allow_a_blocked_shortcode() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 		add_filter( 'wp-piwik_shortcode_authorized', '__return_true' );
 
 		$this->render( 'module=overview' );
@@ -528,7 +603,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_let_the_authorized_filter_block_with_a_wp_error() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$this->deny_through_the_authorized_filter( 'the editorial policy forbids stats here' );
 
 		$output = $this->render( 'module=overview' );
@@ -538,7 +613,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_show_an_administrator_the_message_of_a_wp_error_from_the_authorized_filter() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		$this->deny_through_the_authorized_filter( 'the editorial policy forbids stats here' );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
@@ -549,7 +624,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_report_only_the_first_message_of_a_multi_message_wp_error() {
-		$this->given_a_post_authored_by( $this->create_author( true ) );
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
 		add_filter(
 			'wp-piwik_shortcode_authorized',
 			function () {
@@ -567,7 +642,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_pass_the_attributes_and_the_post_to_the_authorized_filter() {
-		$post_id = $this->given_a_post_authored_by( $this->create_author( true ) );
+		$post_id = $this->create_post_and_set_as_current( $this->create_author( true ) );
 		$seen    = [];
 		add_filter(
 			'wp-piwik_shortcode_authorized',
@@ -594,7 +669,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_return_nothing_to_a_visitor_when_it_blocks_a_shortcode() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 
 		$output = $this->render( 'module=overview' );
 
@@ -602,7 +677,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_render_should_explain_to_an_administrator_why_it_blocked_a_shortcode() {
-		$this->given_a_post_authored_by( $this->create_author( false ) );
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$output = $this->render( 'module=overview' );
@@ -616,16 +691,25 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		return $shortcode->render( shortcode_parse_atts( $attributes ) );
 	}
 
-	private function render_reusable_block( $block_id ) {
-		$block = get_post( $block_id );
+	private function render_reusable_block( $block_id, $block_content = null ) {
+		if ( null === $block_content ) {
+			$block_content = get_post( $block_id )->post_content;
+		}
+		// core hooks callbacks that take the block instance too, so the filter has to be
+		// called with all three arguments the block renderer passes
+		$parsed_block = [
+			'blockName'    => 'core/block',
+			'attrs'        => [ 'ref' => $block_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			'render_block',
-			$block->post_content,
-			[
-				'blockName' => 'core/block',
-				'attrs'     => [ 'ref' => $block_id ],
-			]
+			$block_content,
+			$parsed_block,
+			new \WP_Block( $parsed_block )
 		);
 	}
 
@@ -656,12 +740,17 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		);
 	}
 
+	private function set_pretty_permalink_structure() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->permalink_structure_changed = true;
+	}
+
 	private function grant_read_stats_to_role( $role_name ) {
 		get_role( $role_name )->add_cap( 'wp-piwik_read_stats' );
 		$this->role_caps_to_revoke[] = $role_name;
 	}
 
-	private function given_a_post_authored_by( $author_id ) {
+	private function create_post_and_set_as_current( $author_id ) {
 		$post_id = self::factory()->post->create(
 			[
 				'post_author' => $author_id,

--- a/tests/phpunit/WP_PiwikTest.php
+++ b/tests/phpunit/WP_PiwikTest.php
@@ -2,18 +2,6 @@
 
 namespace WP_Piwik\Tests;
 
-use WP_Piwik\Request;
-
-class Shortcode_Test_Request extends Request {
-
-	protected function request( $id ) {
-	}
-
-	public static function get_registered() {
-		return self::$requests;
-	}
-}
-
 class WP_PiwikTest extends WP_Piwik_TestCase {
 
 	private $settings_backup = array();
@@ -23,111 +11,23 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 
 		$settings              = \WP_Piwik::get_settings();
 		$this->settings_backup = array(
-			'piwik_mode'   => $settings->get_global_option( 'piwik_mode' ),
-			'piwik_url'    => $settings->get_global_option( 'piwik_url' ),
-			'default_date' => $settings->get_global_option( 'default_date' ),
-			'site_id'      => $settings->get_option( 'site_id' ),
+			'piwik_url' => $settings->get_global_option( 'piwik_url' ),
 		);
 
-		$settings->set_global_option( 'piwik_mode', 'disabled' );
 		$settings->set_global_option( 'piwik_url', 'https://matomo.example.org/' );
-		$settings->set_option( 'site_id', 7 );
-
-		$request = new Shortcode_Test_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
-		$request->reset();
 	}
 
 	public function tear_down() {
-		$settings = \WP_Piwik::get_settings();
-		foreach ( array( 'piwik_mode', 'piwik_url', 'default_date' ) as $key ) {
-			$settings->set_global_option( $key, $this->settings_backup[ $key ] );
-		}
-		$settings->set_option( 'site_id', $this->settings_backup['site_id'] );
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_url', $this->settings_backup['piwik_url'] );
 
 		parent::tear_down();
 	}
 
-	public function test_shortcode_should_ignore_an_injected_api_method() {
-		$output = $this->render( 'module=opt-out method=SitesManager.deleteSite' );
+	public function test_shortcode_should_delegate_to_the_shortcode_class() {
+		// the opt-out module needs no authorization and performs no API request, so
+		// rendering it only proves the callback reaches \WP_Piwik\Shortcode
+		$output = $GLOBALS['wp-piwik']->shortcode( shortcode_parse_atts( 'module=opt-out' ) );
 
-		$this->assertStringContainsString( '<iframe', $output, 'precondition: the opt-out widget rendered' );
-		$this->assertSame(
-			array(),
-			Shortcode_Test_Request::get_registered(),
-			'the opt-out widget performs no API call, so it must queue no request at all'
-		);
-	}
-
-	public function test_shortcode_should_drop_unsupported_attributes() {
-		$this->render( 'module=overview method=SitesManager.deleteSite urls=http://attacker.example note=x' );
-
-		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
-		$this->assertSame(
-			array(),
-			array_intersect( array( 'method', 'urls', 'note' ), array_keys( $parameters ) )
-		);
-	}
-
-	public function test_shortcode_should_default_to_the_overview_module() {
-		$this->render( '' );
-
-		$this->assertSame(
-			array( 'VisitsSummary.get' ),
-			$this->get_registered_methods(),
-			'readme.txt documents [wp-piwik] as equal to [wp-piwik module="overview"]'
-		);
-	}
-
-	public function test_shortcode_should_pass_supported_attributes_to_the_widget() {
-		$output = $this->render( 'module=opt-out language=de width=50% height=90px idsite=9' );
-
-		$this->assertStringContainsString( 'width="50%"', $output );
-		$this->assertStringContainsString( 'height="90px"', $output );
-		$this->assertStringContainsString( 'idsite=9', $output );
-		$this->assertStringContainsString( 'language=de', $output );
-	}
-
-	public function test_shortcode_should_keep_honouring_the_default_date_setting() {
-		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
-
-		$this->render( 'module=overview' );
-
-		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
-		$this->assertSame( 'month', $parameters['period'] );
-		$this->assertSame( 'today', $parameters['date'] );
-	}
-
-	public function test_shortcode_should_let_an_explicit_date_win_over_the_default_date_setting() {
-		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
-
-		$this->render( 'module=overview period=day date=last30' );
-
-		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
-		$this->assertSame( 'day', $parameters['period'] );
-		$this->assertSame( 'last30', $parameters['date'] );
-	}
-
-	public function test_shortcode_should_keep_the_post_url_attribute() {
-		$this->render( 'module=post url=https://example.org/some-post/' );
-
-		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
-		$this->assertSame( 'https://example.org/some-post/', $parameters['pageUrl'] );
-	}
-
-	private function render( $attributes ) {
-		return $GLOBALS['wp-piwik']->shortcode( shortcode_parse_atts( $attributes ) );
-	}
-
-	private function get_registered_methods() {
-		return array_values( wp_list_pluck( Shortcode_Test_Request::get_registered(), 'method' ) );
-	}
-
-	private function get_registered_parameters( $method ) {
-		foreach ( Shortcode_Test_Request::get_registered() as $config ) {
-			if ( $method === $config['method'] ) {
-				return $config['parameter'];
-			}
-		}
-		$this->fail( 'No request was registered for ' . $method );
+		$this->assertStringContainsString( '<iframe', $output );
 	}
 }

--- a/tests/phpunit/WP_PiwikTest.php
+++ b/tests/phpunit/WP_PiwikTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request;
+
+class Shortcode_Test_Request extends Request {
+
+	protected function request( $id ) {
+	}
+
+	public static function get_registered() {
+		return self::$requests;
+	}
+}
+
+class WP_PiwikTest extends WP_Piwik_TestCase {
+
+	private $settings_backup = array();
+
+	public function set_up() {
+		parent::set_up();
+
+		$settings              = \WP_Piwik::get_settings();
+		$this->settings_backup = array(
+			'piwik_mode'   => $settings->get_global_option( 'piwik_mode' ),
+			'piwik_url'    => $settings->get_global_option( 'piwik_url' ),
+			'default_date' => $settings->get_global_option( 'default_date' ),
+			'site_id'      => $settings->get_option( 'site_id' ),
+		);
+
+		$settings->set_global_option( 'piwik_mode', 'disabled' );
+		$settings->set_global_option( 'piwik_url', 'https://matomo.example.org/' );
+		$settings->set_option( 'site_id', 7 );
+
+		$request = new Shortcode_Test_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$request->reset();
+	}
+
+	public function tear_down() {
+		$settings = \WP_Piwik::get_settings();
+		foreach ( array( 'piwik_mode', 'piwik_url', 'default_date' ) as $key ) {
+			$settings->set_global_option( $key, $this->settings_backup[ $key ] );
+		}
+		$settings->set_option( 'site_id', $this->settings_backup['site_id'] );
+
+		parent::tear_down();
+	}
+
+	public function test_shortcode_should_ignore_an_injected_api_method() {
+		$output = $this->render( 'module=opt-out method=SitesManager.deleteSite' );
+
+		$this->assertStringContainsString( '<iframe', $output, 'precondition: the opt-out widget rendered' );
+		$this->assertSame(
+			array(),
+			Shortcode_Test_Request::get_registered(),
+			'the opt-out widget performs no API call, so it must queue no request at all'
+		);
+	}
+
+	public function test_shortcode_should_drop_unsupported_attributes() {
+		$this->render( 'module=overview method=SitesManager.deleteSite urls=http://attacker.example note=x' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame(
+			array(),
+			array_intersect( array( 'method', 'urls', 'note' ), array_keys( $parameters ) )
+		);
+	}
+
+	public function test_shortcode_should_default_to_the_overview_module() {
+		$this->render( '' );
+
+		$this->assertSame(
+			array( 'VisitsSummary.get' ),
+			$this->get_registered_methods(),
+			'readme.txt documents [wp-piwik] as equal to [wp-piwik module="overview"]'
+		);
+	}
+
+	public function test_shortcode_should_pass_supported_attributes_to_the_widget() {
+		$output = $this->render( 'module=opt-out language=de width=50% height=90px idsite=9' );
+
+		$this->assertStringContainsString( 'width="50%"', $output );
+		$this->assertStringContainsString( 'height="90px"', $output );
+		$this->assertStringContainsString( 'idsite=9', $output );
+		$this->assertStringContainsString( 'language=de', $output );
+	}
+
+	public function test_shortcode_should_keep_honouring_the_default_date_setting() {
+		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
+
+		$this->render( 'module=overview' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( 'month', $parameters['period'] );
+		$this->assertSame( 'today', $parameters['date'] );
+	}
+
+	public function test_shortcode_should_let_an_explicit_date_win_over_the_default_date_setting() {
+		\WP_Piwik::get_settings()->set_global_option( 'default_date', 'current_month' );
+
+		$this->render( 'module=overview period=day date=last30' );
+
+		$parameters = $this->get_registered_parameters( 'VisitsSummary.get' );
+		$this->assertSame( 'day', $parameters['period'] );
+		$this->assertSame( 'last30', $parameters['date'] );
+	}
+
+	public function test_shortcode_should_keep_the_post_url_attribute() {
+		$this->render( 'module=post url=https://example.org/some-post/' );
+
+		$parameters = $this->get_registered_parameters( 'Actions.getPageUrl' );
+		$this->assertSame( 'https://example.org/some-post/', $parameters['pageUrl'] );
+	}
+
+	private function render( $attributes ) {
+		return $GLOBALS['wp-piwik']->shortcode( shortcode_parse_atts( $attributes ) );
+	}
+
+	private function get_registered_methods() {
+		return array_values( wp_list_pluck( Shortcode_Test_Request::get_registered(), 'method' ) );
+	}
+
+	private function get_registered_parameters( $method ) {
+		foreach ( Shortcode_Test_Request::get_registered() as $config ) {
+			if ( $method === $config['method'] ) {
+				return $config['parameter'];
+			}
+		}
+		$this->fail( 'No request was registered for ' . $method );
+	}
+}

--- a/wp-piwik.php
+++ b/wp-piwik.php
@@ -3,7 +3,7 @@
  * Plugin Name: Connect Matomo
  * Plugin URI: http://wordpress.org/extend/plugins/wp-piwik/
  * Description: Adds Matomo statistics to your WordPress dashboard and is also able to add the Matomo Tracking Code to your blog.
- * Version: 1.1.10
+ * Version: 1.1.11
  * Author: Matomo, Andr&eacute; Br&auml;kling
  * Author URI: https://matomo.org
  * Text Domain: wp-piwik


### PR DESCRIPTION
### Description

Changes:
* allowlist short code parameters and move default values to widgets (if not already there).
* ensure method is always set to the method in the config (so it cannot be overridden by parameters)
* don't queue a pointless request in the OptOut widget
* fix potential double encoding in iframe attribute output
* correct iframe parameter defaults when parameters are not supplied
* make sure the author who uses the post shortcode is authorized to see stats
* make sure the URL used in the post shortcode is allowed based on the author using the shortcode
* make sure blocks that use the shortcode use the block author during authorization

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
